### PR TITLE
Support aria-live messages to report what changes as the game is played

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -46,7 +46,7 @@
 
     <p><label for="gameSelection">Currently playing:</label>
         <select id="gameSelection">
-            <!-- Works well now -->
+            <option disabled="disabled">--- Works Well Now ---</option>
             <option value="f0b9b8e95d0bc87c9fb9e411756daa23">IceCrates⁣</option>
             <option value="7f4470ab80d9f7ffe4b9e28c83b26adc">PUSH⁣</option>
             <option value="_pot-wash-panic_itch">Pot Wash Panic</option>
@@ -60,22 +60,22 @@
             <option value="_sleepy-player_itch">Sleepy players⁣</option>
 
 
-            <!-- Has extra messages about temp state that should be filtered out -->
+            <option disabled="disabled">--- Works but are a little too verbose ---</option>
+            <option value="_skipping-stones_d6fd6fcf84de185e2584">Skipping Stones to Lonely Homes⁣</option>
             <option value="8074d60a0af768f970ef055d4460414d">Bubble Butler: CMD REORGANIZE⁣</option>
             <option value="ee39bfe12012c774acfc5e3d32fb4f89">Boxes &amp; Balloons⁣</option>
             <option value="_mirror-isles_219a7db6511dad557b84">Mirror Isles⁣</option>
             <option value="e86e1d6cf24307499c1cd1aaaa733a91">SwapBot⁣</option>
             <option value="_spikes-n-stuff_dc5c4a669e362e389e994025075f7d0b">Spikes 'n' Stuff⁣</option>
 
-            <!-- Has extra animation messages but could be ok -->
+            <option disabled="disabled">--- Works but have more animation messages than needed ---</option>
             <option value="_spacekoban_6a6c07f71d7039e4155e">Spacekoban⁣</option>
             <option value="181f370a15625905ca6e844a972a4abf">Miss Direction⁣</option>
             <option value="711d6220e4fe2a36254cc544c6ba4885">Memories Of Castlemouse⁣</option>
             <option value="_rosden.itch.io_islands">Islands⁣</option>
             <option value="_rosden.itch.io_bomb-n-ice">bomb n ice⁣</option>
 
-
-            <!-- Has many animations -->
+            <option disabled="disabled">--- Works but have many animation messages ---</option>
             <option value="_cyber-lasso-e3e444f7c63fb21b6ec0">Cyber-Lasso⁣</option>
             <option value="_boxes-love-bloxing_c2d717a77f9aa02ecb1b793111f3a921">Boxes Love Bloxing Gloves⁣</option>
             <option value="_hack-the-net_8b5eb39cb825277832d261b3142f084b">Hack the Net⁣</option>
@@ -86,7 +86,6 @@
             <option value="542b97948cb1d377dce6d276c0bcd9d5">Sokoboros⁣</option>
             <option value="2b9ece642cd7cdfb4a5f2c9fa8455e40">Beam Islands⁣</option>
             <option value="_entanglement">Entanglement - Chapter One⁣</option>
-            <option value="_skipping-stones_d6fd6fcf84de185e2584">Skipping Stones to Lonely Homes⁣</option>
         </select>
 
         <span id="loadingIndicator" class="hidden">Loading...</span>
@@ -135,9 +134,9 @@
             }
         }
 
-        // var worker = new Worker('./lib/puzzlescript-webworker.js')
-        // var tableEngine = new window.PuzzleScript.WebworkerTableEngine(worker, table, handler)
-        var tableEngine = new window.PuzzleScript.SyncTableEngine(table, handler)
+        var worker = new Worker('./lib/puzzlescript-webworker.js')
+        var tableEngine = new window.PuzzleScript.WebworkerTableEngine(worker, table, handler)
+        // var tableEngine = new window.PuzzleScript.SyncTableEngine(table, handler)
 
         function playSelectedGame() {
             loadingIndicator.classList.remove('hidden') // Show the "Loading..." text

--- a/index.xhtml
+++ b/index.xhtml
@@ -101,7 +101,7 @@
     </table>
 
 
-    <p><input id="ui-enable" type="checkbox" checked="checked"/> <label for="ui-enable"><strong>Uncheck</strong> to see what a non-sighted user would experience</label></p>
+    <p><input id="ui-enable" type="checkbox" checked="checked"/> <label for="ui-enable"><strong>Uncheck</strong> to see what a non-sighted user would experience (disables CSS)</label></p>
 
     <div id="gameInstructions">
         <p>To play:</p>

--- a/index.xhtml
+++ b/index.xhtml
@@ -5,6 +5,7 @@
     <script src="./lib/puzzlescript.js"></script>
     <link rel="stylesheet" href="./style.css"/>
     <style>
+        body { font-family: helvetica, arial, sans-serif; }
         .hidden { display: none; }
         .light { opacity: .5 }
         kbd {
@@ -43,56 +44,74 @@
 <body>
     <h1>Example <a href="https://github.com/philschatz/puzzlescript">PuzzleScript Games</a> using HTML Tables</h1>
 
-    <p>Currently playing:
+    <p><label for="gameSelection">Currently playing:</label>
         <select id="gameSelection">
+            <!-- Works well now -->
             <option value="f0b9b8e95d0bc87c9fb9e411756daa23">IceCrates⁣</option>
             <option value="7f4470ab80d9f7ffe4b9e28c83b26adc">PUSH⁣</option>
-            <option value="ee39bfe12012c774acfc5e3d32fb4f89">Boxes &amp; Balloons⁣</option>
             <option value="_pot-wash-panic_itch">Pot Wash Panic</option>
             <option value="457c6d8be68ffb6d921211d40ca48c15">Pants, Shirt, Cap⁣</option>
-            <option value="_cyber-lasso-e3e444f7c63fb21b6ec0">Cyber-Lasso⁣</option>
             <option value="e13482e035a5f75e9b0e4d0b5f28f8b6">Pushcat Jr⁣</option>
-            <option value="_mirror-isles_219a7db6511dad557b84">Mirror Isles⁣</option>
-            <option value="_boxes-love-bloxing_c2d717a77f9aa02ecb1b793111f3a921">Boxes Love Bloxing Gloves⁣</option>
             <!-- <option value="a4829564ab394e720a82cf25d6c9cd91">Garten der Medusen⁣</option> -->
-            <option value="e86e1d6cf24307499c1cd1aaaa733a91">SwapBot⁣</option>
             <option value="_separation_itch">Separation⁣</option>
             <option value="_roll-those-sixes-itch">Roll those Sixes⁣</option>
-            <option value="_hack-the-net_8b5eb39cb825277832d261b3142f084b">Hack the Net⁣</option>
-            <option value="_spacekoban_6a6c07f71d7039e4155e">Spacekoban⁣</option>
-            <option value="_spikes-n-stuff_dc5c4a669e362e389e994025075f7d0b">Spikes 'n' Stuff⁣</option>
             <option value="6daa8b63cf79202cd085c1b168048c09">Rock, Paper, Scissors (v0.90 = v1.alpha)⁣</option>
-            <option value="_spooky-pumpkin_7242443">Spooky Pumpkin Game⁣</option>
-            <option value="181f370a15625905ca6e844a972a4abf">Miss Direction⁣</option>
             <option value="c5ec035de4e0c145a85327942fb76098">Some lines were meant to be crossed⁣</option>
-            <option value="711d6220e4fe2a36254cc544c6ba4885">Memories Of Castlemouse⁣</option>
-            <option value="8074d60a0af768f970ef055d4460414d">Bubble Butler: CMD REORGANIZE⁣</option>
             <option value="_sleepy-player_itch">Sleepy players⁣</option>
-            <option value="_rosden.itch.io_bomb-n-ice">bomb n ice⁣</option>
-            <option value="_alien-disco_itch">Alien Disco⁣</option>
 
+
+            <!-- Has extra messages about temp state that should be filtered out -->
+            <option value="8074d60a0af768f970ef055d4460414d">Bubble Butler: CMD REORGANIZE⁣</option>
+            <option value="ee39bfe12012c774acfc5e3d32fb4f89">Boxes &amp; Balloons⁣</option>
+            <option value="_mirror-isles_219a7db6511dad557b84">Mirror Isles⁣</option>
+            <option value="e86e1d6cf24307499c1cd1aaaa733a91">SwapBot⁣</option>
+            <option value="_spikes-n-stuff_dc5c4a669e362e389e994025075f7d0b">Spikes 'n' Stuff⁣</option>
+
+            <!-- Has extra animation messages but could be ok -->
+            <option value="_spacekoban_6a6c07f71d7039e4155e">Spacekoban⁣</option>
+            <option value="181f370a15625905ca6e844a972a4abf">Miss Direction⁣</option>
+            <option value="711d6220e4fe2a36254cc544c6ba4885">Memories Of Castlemouse⁣</option>
+            <option value="_rosden.itch.io_islands">Islands⁣</option>
+            <option value="_rosden.itch.io_bomb-n-ice">bomb n ice⁣</option>
+
+
+            <!-- Has many animations -->
+            <option value="_cyber-lasso-e3e444f7c63fb21b6ec0">Cyber-Lasso⁣</option>
+            <option value="_boxes-love-bloxing_c2d717a77f9aa02ecb1b793111f3a921">Boxes Love Bloxing Gloves⁣</option>
+            <option value="_hack-the-net_8b5eb39cb825277832d261b3142f084b">Hack the Net⁣</option>
+            <option value="_spooky-pumpkin_7242443">Spooky Pumpkin Game⁣</option>
+
+            <option value="_alien-disco_itch">Alien Disco⁣</option>
             <option value="b6c8ba9363b4cca270d8ce5e88f79abf">Vacuum⁣</option>
             <option value="542b97948cb1d377dce6d276c0bcd9d5">Sokoboros⁣</option>
             <option value="2b9ece642cd7cdfb4a5f2c9fa8455e40">Beam Islands⁣</option>
             <option value="_entanglement">Entanglement - Chapter One⁣</option>
-            <option value="_rosden.itch.io_islands">Islands⁣</option>
             <option value="_skipping-stones_d6fd6fcf84de185e2584">Skipping Stones to Lonely Homes⁣</option>
         </select>
 
         <span id="loadingIndicator" class="hidden">Loading...</span>
     </p>
     
-    <table id="theGame"></table>
+    <table id="theGame" aria-labelledby="gameInstructions">
+        <caption>
+            Game info goes here. like the current level, the goal, etc.
+            <!-- See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions -->
+            <div role="log" aria-live="polite">The Game log</div>
+        </caption>
+    </table>
+
 
     <p><input id="ui-enable" type="checkbox" checked="checked"/> <label for="ui-enable"><strong>Uncheck</strong> to see what a non-sighted user would experience</label></p>
 
-    <p>To play:</p>
-    <ul>
-        <li>Arrow keys or <kbd>W</kbd>, <kbd>S</kbd>, <kbd>A</kbd>, <kbd>D</kbd></li>
-        <li><kbd>X</kbd> for Action</li>
-        <li><kbd>Z</kbd> or <kbd>U</kbd> for Undo</li>
-        <li><kbd>R</kbd> to Restart the current level</li>
-    </ul>
+    <div id="gameInstructions">
+        <p>To play:</p>
+        <ul>
+            <li>Arrow keys or <kbd>W</kbd>, <kbd>S</kbd>, <kbd>A</kbd>, <kbd>D</kbd></li>
+            <li><kbd>X</kbd> for Action</li>
+            <li><kbd>Z</kbd> or <kbd>U</kbd> for Undo</li>
+            <li><kbd>R</kbd> to Restart the current level</li>
+        </ul>
+    </div>
 
     <p id="gamepadDisabled" class="hidden"><strong>Tip:</strong> Connect a gamepad controller (XBOX/PS3/PS4/etc) to use it to play games</p>
     <p id="gamepadEnabled" class="hidden">Gamepad is detected</p>
@@ -116,9 +135,9 @@
             }
         }
 
-        var worker = new Worker('./lib/puzzlescript-webworker.js')
-        var tableEngine = new window.PuzzleScript.WebworkerTableEngine(worker, table, handler)
-        // var tableEngine = new window.PuzzleScript.SyncTableEngine(table, handler)
+        // var worker = new Worker('./lib/puzzlescript-webworker.js')
+        // var tableEngine = new window.PuzzleScript.WebworkerTableEngine(worker, table, handler)
+        var tableEngine = new window.PuzzleScript.SyncTableEngine(table, handler)
 
         function playSelectedGame() {
             loadingIndicator.classList.remove('hidden') // Show the "Loading..." text

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bitset": "^5.0.4",
     "chalk": "^2.4.1",
     "commander": "^2.19.0",
-    "contro": "github:philschatz/contro#3fb450c076262a3338535341550259c2f3391de7",
+    "contro": "github:philschatz/contro#51a450da7758f0754bed7d2248942a4557d112fc",
     "eventemitter2": "^5.0.1",
     "firstline": "^2.0.2",
     "font-ascii": "^1.1.16",

--- a/src/browser/ResizeWatcher.ts
+++ b/src/browser/ResizeWatcher.ts
@@ -12,7 +12,7 @@ export default class ResizeWatcher {
         this.handler = handler
         this.columns = 1
         this.rows = 1
-        this.boundResizeHandler = _debounce(this.resizeHandler.bind(this))
+        this.boundResizeHandler = _debounce(this.trigger.bind(this))
 
         window.addEventListener('resize', this.boundResizeHandler)
     }
@@ -22,7 +22,7 @@ export default class ResizeWatcher {
         this.columns = columns
     }
 
-    public resizeHandler() {
+    public trigger() {
         // Resize the table so that it fits.
         const levelRatio = this.columns / this.rows
         // Figure out if the width or the height is the limiting factor

--- a/src/browser/SyncTableEngine.ts
+++ b/src/browser/SyncTableEngine.ts
@@ -118,6 +118,7 @@ export default class SyncTableEngine implements Engineish {
         }
         this.subEngine.start()
         this.table.focus()
+        this.resizeWatcher.trigger()
     }
     public dispose() {
         this.subEngine.dispose()

--- a/src/browser/WebworkerTableEngine.ts
+++ b/src/browser/WebworkerTableEngine.ts
@@ -130,7 +130,7 @@ export default class WebworkerTableEngine implements Engineish {
                 } else {
                     this.ui.onLevelChange(data.level, null, data.message)
                 }
-                this.resizeWatcher.resizeHandler() // force resize
+                this.resizeWatcher.trigger() // force resize
                 this.table.focus()
                 break
             case MESSAGE_TYPE.ON_MESSAGE:

--- a/src/browser/WebworkerTableEngine.ts
+++ b/src/browser/WebworkerTableEngine.ts
@@ -175,7 +175,11 @@ export default class WebworkerTableEngine implements Engineish {
                 case A11Y_MESSAGE_TYPE.REMOVE:
                     return { ...message, cell: this.convertToCellish(message.cell), sprites: [...message.sprites].map((n) => this.lookupSprite(n)) }
                 case A11Y_MESSAGE_TYPE.REPLACE:
-                    return { ...message, cell: this.convertToCellish(message.cell), replacements: [...message.replacements].map(({ oldSprite, newSprite }) =>({ oldSprite: this.lookupSprite(oldSprite), newSprite: this.lookupSprite(newSprite) })) }
+                    return {
+                        ...message,
+                        cell: this.convertToCellish(message.cell),
+                        replacements: [...message.replacements].map(({ oldSprite, newSprite }) => ({ oldSprite: this.lookupSprite(oldSprite), newSprite: this.lookupSprite(newSprite) }))
+                    }
             }
         })
     }

--- a/src/browser/WebworkerTableEngine.ts
+++ b/src/browser/WebworkerTableEngine.ts
@@ -1,9 +1,11 @@
 import { GameData } from '../models/game'
+import { A11Y_MESSAGE, A11Y_MESSAGE_TYPE } from '../models/rule'
 import { GameSprite } from '../models/tile'
 import { LEVEL_TYPE } from '../parser/astTypes'
 import Serializer from '../parser/serializer'
 import TableUI from '../ui/table'
 import { Cellish,
+    CellishJson,
     Engineish,
     GameEngineHandlerOptional,
     INPUT_BUTTON,
@@ -12,7 +14,7 @@ import { Cellish,
     pollingPromise,
     PuzzlescriptWorker,
     RULE_DIRECTION,
-    WorkerResponse } from '../util'
+    WorkerResponse} from '../util'
 import InputWatcher from './InputWatcher'
 import ResizeWatcher from './ResizeWatcher'
 
@@ -142,7 +144,7 @@ export default class WebworkerTableEngine implements Engineish {
                 this.ui.onPress(data.direction)
                 break
             case MESSAGE_TYPE.ON_TICK:
-                this.ui.onTick(new Set(data.changedCells.map((x) => this.convertToCellish(x))), data.hasAgain)
+                this.ui.onTick(new Set(data.changedCells.map((x) => this.convertToCellish(x))), data.hasAgain, this.convertToA11yMessages(data.a11yMessages))
                 break
             case MESSAGE_TYPE.ON_SOUND:
                 await this.ui.onSound({ soundCode: data.soundCode })
@@ -163,6 +165,27 @@ export default class WebworkerTableEngine implements Engineish {
                 console.log(`BUG: Unhandled Event occurred. Ignoring "${data.type}"`, data) // tslint:disable-line:no-console
         }
     }
+    private convertToA11yMessages(a11yMessages: Array<A11Y_MESSAGE<CellishJson, string>>): Array<A11Y_MESSAGE<Cellish, GameSprite>> {
+        return a11yMessages.map((message) => {
+            switch (message.type) {
+                case A11Y_MESSAGE_TYPE.ADD:
+                    return { ...message, cell: this.convertToCellish(message.cell), sprites: [...message.sprites].map((n) => this.lookupSprite(n)) }
+                case A11Y_MESSAGE_TYPE.MOVE:
+                    return { ...message, oldCell: this.convertToCellish(message.oldCell), newCell: this.convertToCellish(message.newCell), sprite: this.lookupSprite(message.sprite) }
+                case A11Y_MESSAGE_TYPE.REMOVE:
+                    return { ...message, cell: this.convertToCellish(message.cell), sprites: [...message.sprites].map((n) => this.lookupSprite(n)) }
+                case A11Y_MESSAGE_TYPE.REPLACE:
+                    return { ...message, cell: this.convertToCellish(message.cell), replacements: [...message.replacements].map(({ oldSprite, newSprite }) =>({ oldSprite: this.lookupSprite(oldSprite), newSprite: this.lookupSprite(newSprite) })) }
+            }
+        })
+    }
+    private lookupSprite(name: string) {
+        const sprite = this.getGameData()._getSpriteByName(name)
+        if (!sprite) {
+            throw new Error(`Could not find sprite "${name}"`)
+        }
+        return sprite
+    }
     private convertToCellish(c: {rowIndex: number, colIndex: number, spriteNames: string[]}) {
         const { rowIndex, colIndex, spriteNames } = c
 
@@ -176,13 +199,7 @@ export default class WebworkerTableEngine implements Engineish {
 
         const cell = this.cellCache[rowIndex][colIndex]
 
-        cell.sprites = spriteNames.map((name) => {
-            const sprite = this.getGameData()._getSpriteByName(name)
-            if (!sprite) {
-                throw new Error(`Could not find sprite "${name}"`)
-            }
-            return sprite
-        })
+        cell.sprites = spriteNames.map((name) => this.lookupSprite(name))
 
         return cell
     }

--- a/src/browser/spec/html-table-webworker.xhtml
+++ b/src/browser/spec/html-table-webworker.xhtml
@@ -7,8 +7,12 @@
 </head>
 
 <body>
-    <table id="the-game"></table>
-    
+    <table id="the-game">
+        <caption>
+            <div role="log" aria-live="polite">The Game log</div>
+        </caption>
+    </table>
+        
     <script type="text/javascript">//<![CDATA[
         /* eslint-env browser */
         const { PuzzleScript } = window

--- a/src/browser/spec/html-table.xhtml
+++ b/src/browser/spec/html-table.xhtml
@@ -7,7 +7,11 @@
 </head>
 
 <body>
-    <table id="the-game"></table>
+    <table id="the-game">
+        <caption>
+            <div role="log" aria-live="polite">The Game log</div>
+        </caption>
+    </table>
     
     <script type="text/javascript">//<![CDATA[
         /* eslint-env browser */

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,7 +2,7 @@ import { EventEmitter2, Listener } from 'eventemitter2'
 import { logger } from './logger'
 import { CollisionLayer } from './models/collisionLayer'
 import { GameData } from './models/game'
-import { IMutation, SimpleRuleGroup, MoveMutation, REPLACE_TYPE } from './models/rule'
+import { A11Y_MESSAGE, A11Y_MESSAGE_TYPE, IMutation, SimpleRuleGroup } from './models/rule'
 import { GameSprite, IGameTile } from './models/tile'
 import { Command, COMMAND_TYPE, LEVEL_TYPE, SoundItem } from './parser/astTypes'
 import { SpriteBitSet } from './spriteBitSet'
@@ -466,7 +466,8 @@ export class LevelEngine extends EventEmitter2 {
                     messageToShow: null,
                     hasRestart: false,
                     isWinning: false,
-                    mutations: new Set<IMutation>()
+                    mutations: [],
+                    a11yMessages: []
                 }
             case INPUT_BUTTON.RESTART:
                 this.doRestart()
@@ -477,7 +478,8 @@ export class LevelEngine extends EventEmitter2 {
                     messageToShow: null,
                     hasRestart: true,
                     isWinning: false,
-                    mutations: new Set<IMutation>()
+                    mutations: [],
+                    a11yMessages: []
                 }
             default:
               // no-op
@@ -522,7 +524,8 @@ export class LevelEngine extends EventEmitter2 {
             messageToShow,
             hasRestart,
             isWinning: hasWinCommand || this.isWinning(),
-            mutations: ret.mutations
+            mutations: ret.mutations,
+            a11yMessages: ret.a11yMessages
         }
     }
 
@@ -545,7 +548,7 @@ export class LevelEngine extends EventEmitter2 {
 
     public /*only for unit tests*/ tickMoveSprites(changedCells: Set<Cell>) {
         const movedCells: Set<Cell> = new Set()
-        const movedMutations: IMutation[] = []
+        const a11yMessages: Array<A11Y_MESSAGE<Cell, GameSprite>> = []
         // Loop over all the cells, see if a Rule matches, apply the transition, and notify that cells changed
         let somethingChanged
         do {
@@ -575,7 +578,7 @@ export class LevelEngine extends EventEmitter2 {
                                 movedCells.add(cell)
                                 somethingChanged = true
 
-                                movedMutations.push(new MoveMutation({type: REPLACE_TYPE.MOVE, oldCell: cell, newCell: neighbor, sprite, direction: wantsToMove}))
+                                a11yMessages.push({ type: A11Y_MESSAGE_TYPE.MOVE, oldCell: cell, newCell: neighbor, sprite, direction: wantsToMove })
                                 // Don't delete until we are sure none of the sprites want to move
                                 // changedCells.delete(cell)
                             } else {
@@ -597,7 +600,7 @@ export class LevelEngine extends EventEmitter2 {
                 cell.clearWantsToMove(sprite)
             }
         }
-        return { movedCells, movedMutations }
+        return { movedCells, a11yMessages }
     }
 
     private pressDir(direction: INPUT_BUTTON) {
@@ -703,6 +706,7 @@ export class LevelEngine extends EventEmitter2 {
 
     private _tickUpdateCells(rules: Iterable<SimpleRuleGroup>) {
         const changedMutations: Set<IMutation> = new Set()
+        const a11yMessages: Array<A11Y_MESSAGE<Cell, GameSprite>> = []
         const evaluatedRules: SimpleRuleGroup[] = []
         if (!this.currentLevel) {
             throw new Error(`BUG: Level Cells do not exist yet`)
@@ -714,6 +718,9 @@ export class LevelEngine extends EventEmitter2 {
             }
             for (const mutation of cellMutations) {
                 changedMutations.add(mutation)
+                for (const message of mutation.messages) {
+                    a11yMessages.push(message)
+                }
             }
         }
 
@@ -727,7 +734,7 @@ export class LevelEngine extends EventEmitter2 {
                 commands.add(mutation.getCommand())
             }
         }
-        return { evaluatedRules, changedCells, commands, mutations: changedMutations }
+        return { evaluatedRules, changedCells, commands, mutations: changedMutations, a11yMessages }
     }
 
     private tickNormal() {
@@ -750,7 +757,7 @@ export class LevelEngine extends EventEmitter2 {
             logger.debug(() => `Turn starts with no input.`)
         }
 
-        const { changedCells: changedCellMutations2, evaluatedRules, commands, mutations } = this.tickUpdateCells()
+        const { changedCells: changedCellMutations2, evaluatedRules, commands, mutations, a11yMessages: a11yMessages1 } = this.tickUpdateCells()
         changedCellMutations = setAddAll(changedCellMutations, changedCellMutations2)
 
         // Continue evaluating again rules only when some sprites have changed
@@ -758,8 +765,8 @@ export class LevelEngine extends EventEmitter2 {
         // a rule might add a sprite, and then another rule might remove a sprite.
         // We need to compare the set of sprites before and after ALL rules ran.
         // This will likely be implemented as part of UNDO or CHECKPOINT.
-        const { movedCells, movedMutations } = this.tickMoveSprites(new Set<Cell>(changedCellMutations.keys()))
-        const { changedCells: changedCellsLate, evaluatedRules: evaluatedRulesLate, commands: commandsLate, mutations: mutationsLate } = this.tickUpdateCellsLate()
+        const { movedCells, a11yMessages: a11yMessages2 } = this.tickMoveSprites(new Set<Cell>(changedCellMutations.keys()))
+        const { changedCells: changedCellsLate, evaluatedRules: evaluatedRulesLate, commands: commandsLate, mutations: mutationsLate, a11yMessages: a11yMessages3 } = this.tickUpdateCellsLate()
         const allCommands = [...commands, ...commandsLate]
         const didCancel = !!allCommands.filter((c) => c.type === COMMAND_TYPE.CANCEL)[0]
         if (didCancel) {
@@ -771,7 +778,8 @@ export class LevelEngine extends EventEmitter2 {
                 changedCells: new Set<Cell>(),
                 commands: new Set<Command<SoundItem<IGameTile>>>(),
                 evaluatedRules,
-                mutations: new Set<IMutation>()
+                mutations: new Set<IMutation>(),
+                a11yMessages: []
             }
         }
         const didCheckpoint = !!allCommands.find((c) => c.type === COMMAND_TYPE.CHECKPOINT)
@@ -789,7 +797,8 @@ export class LevelEngine extends EventEmitter2 {
             changedCells,
             evaluatedRules: evaluatedRules.concat(evaluatedRulesLate),
             commands: allCommands,
-            mutations: new Set([...mutations, ...mutationsLate, ...movedMutations])
+            mutations: new Set([...mutations, ...mutationsLate]),
+            a11yMessages: [...a11yMessages1, ...a11yMessages2, ...a11yMessages3]
         }
     }
 
@@ -935,14 +944,14 @@ export class GameEngine {
         }
 
         const previousPending = this.levelEngine.pendingPlayerWantsToMove
-        const { changedCells, soundToPlay, messageToShow, isWinning, hasRestart, mutations } = this.levelEngine.tick()
+        const { changedCells, soundToPlay, messageToShow, isWinning, hasRestart, a11yMessages } = this.levelEngine.tick()
 
         if (previousPending && !this.levelEngine.pendingPlayerWantsToMove) {
             this.handler.onPress(previousPending)
         }
 
         if (hasRestart) {
-            this.handler.onTick(changedCells, hasAgain, mutations)
+            this.handler.onTick(changedCells, hasAgain, a11yMessages)
             return {
                 changedCells,
                 didWinGame: false,
@@ -952,7 +961,7 @@ export class GameEngine {
         }
 
         hasAgain = this.levelEngine.hasAgain()
-        this.handler.onTick(changedCells, hasAgain, mutations)
+        this.handler.onTick(changedCells, hasAgain, a11yMessages)
         let didWinGame = false
         if (isWinning) {
             if (this.currentLevelNum === this.levelEngine.gameData.levels.length - 1) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,7 +2,7 @@ import { EventEmitter2, Listener } from 'eventemitter2'
 import { logger } from './logger'
 import { CollisionLayer } from './models/collisionLayer'
 import { GameData } from './models/game'
-import { IMutation, SimpleRuleGroup } from './models/rule'
+import { IMutation, SimpleRuleGroup, MoveMutation, REPLACE_TYPE } from './models/rule'
 import { GameSprite, IGameTile } from './models/tile'
 import { Command, COMMAND_TYPE, LEVEL_TYPE, SoundItem } from './parser/astTypes'
 import { SpriteBitSet } from './spriteBitSet'
@@ -465,7 +465,8 @@ export class LevelEngine extends EventEmitter2 {
                     soundToPlay: null,
                     messageToShow: null,
                     hasRestart: false,
-                    isWinning: false
+                    isWinning: false,
+                    mutations: new Set<IMutation>()
                 }
             case INPUT_BUTTON.RESTART:
                 this.doRestart()
@@ -475,7 +476,8 @@ export class LevelEngine extends EventEmitter2 {
                     soundToPlay: null,
                     messageToShow: null,
                     hasRestart: true,
-                    isWinning: false
+                    isWinning: false,
+                    mutations: new Set<IMutation>()
                 }
             default:
               // no-op
@@ -519,7 +521,8 @@ export class LevelEngine extends EventEmitter2 {
             soundToPlay,
             messageToShow,
             hasRestart,
-            isWinning: hasWinCommand || this.isWinning()
+            isWinning: hasWinCommand || this.isWinning(),
+            mutations: ret.mutations
         }
     }
 
@@ -542,6 +545,7 @@ export class LevelEngine extends EventEmitter2 {
 
     public /*only for unit tests*/ tickMoveSprites(changedCells: Set<Cell>) {
         const movedCells: Set<Cell> = new Set()
+        const movedMutations: IMutation[] = []
         // Loop over all the cells, see if a Rule matches, apply the transition, and notify that cells changed
         let somethingChanged
         do {
@@ -570,6 +574,8 @@ export class LevelEngine extends EventEmitter2 {
                                 movedCells.add(neighbor)
                                 movedCells.add(cell)
                                 somethingChanged = true
+
+                                movedMutations.push(new MoveMutation({type: REPLACE_TYPE.MOVE, oldCell: cell, newCell: neighbor, sprite, direction: wantsToMove}))
                                 // Don't delete until we are sure none of the sprites want to move
                                 // changedCells.delete(cell)
                             } else {
@@ -591,7 +597,7 @@ export class LevelEngine extends EventEmitter2 {
                 cell.clearWantsToMove(sprite)
             }
         }
-        return movedCells
+        return { movedCells, movedMutations }
     }
 
     private pressDir(direction: INPUT_BUTTON) {
@@ -721,7 +727,7 @@ export class LevelEngine extends EventEmitter2 {
                 commands.add(mutation.getCommand())
             }
         }
-        return { evaluatedRules, changedCells, commands }
+        return { evaluatedRules, changedCells, commands, mutations: changedMutations }
     }
 
     private tickNormal() {
@@ -744,7 +750,7 @@ export class LevelEngine extends EventEmitter2 {
             logger.debug(() => `Turn starts with no input.`)
         }
 
-        const { changedCells: changedCellMutations2, evaluatedRules, commands } = this.tickUpdateCells()
+        const { changedCells: changedCellMutations2, evaluatedRules, commands, mutations } = this.tickUpdateCells()
         changedCellMutations = setAddAll(changedCellMutations, changedCellMutations2)
 
         // Continue evaluating again rules only when some sprites have changed
@@ -752,8 +758,8 @@ export class LevelEngine extends EventEmitter2 {
         // a rule might add a sprite, and then another rule might remove a sprite.
         // We need to compare the set of sprites before and after ALL rules ran.
         // This will likely be implemented as part of UNDO or CHECKPOINT.
-        const movedCells = this.tickMoveSprites(new Set<Cell>(changedCellMutations.keys()))
-        const { changedCells: changedCellsLate, evaluatedRules: evaluatedRulesLate, commands: commandsLate } = this.tickUpdateCellsLate()
+        const { movedCells, movedMutations } = this.tickMoveSprites(new Set<Cell>(changedCellMutations.keys()))
+        const { changedCells: changedCellsLate, evaluatedRules: evaluatedRulesLate, commands: commandsLate, mutations: mutationsLate } = this.tickUpdateCellsLate()
         const allCommands = [...commands, ...commandsLate]
         const didCancel = !!allCommands.filter((c) => c.type === COMMAND_TYPE.CANCEL)[0]
         if (didCancel) {
@@ -764,7 +770,8 @@ export class LevelEngine extends EventEmitter2 {
             return {
                 changedCells: new Set<Cell>(),
                 commands: new Set<Command<SoundItem<IGameTile>>>(),
-                evaluatedRules
+                evaluatedRules,
+                mutations: new Set<IMutation>()
             }
         }
         const didCheckpoint = !!allCommands.find((c) => c.type === COMMAND_TYPE.CHECKPOINT)
@@ -781,7 +788,8 @@ export class LevelEngine extends EventEmitter2 {
         return {
             changedCells,
             evaluatedRules: evaluatedRules.concat(evaluatedRulesLate),
-            commands: allCommands
+            commands: allCommands,
+            mutations: new Set([...mutations, ...mutationsLate, ...movedMutations])
         }
     }
 
@@ -927,14 +935,14 @@ export class GameEngine {
         }
 
         const previousPending = this.levelEngine.pendingPlayerWantsToMove
-        const { changedCells, soundToPlay, messageToShow, isWinning, hasRestart } = this.levelEngine.tick()
+        const { changedCells, soundToPlay, messageToShow, isWinning, hasRestart, mutations } = this.levelEngine.tick()
 
         if (previousPending && !this.levelEngine.pendingPlayerWantsToMove) {
             this.handler.onPress(previousPending)
         }
 
         if (hasRestart) {
-            this.handler.onTick(changedCells, hasAgain)
+            this.handler.onTick(changedCells, hasAgain, mutations)
             return {
                 changedCells,
                 didWinGame: false,
@@ -944,7 +952,7 @@ export class GameEngine {
         }
 
         hasAgain = this.levelEngine.hasAgain()
-        this.handler.onTick(changedCells, hasAgain)
+        this.handler.onTick(changedCells, hasAgain, mutations)
         let didWinGame = false
         if (isWinning) {
             if (this.currentLevelNum === this.levelEngine.gameData.levels.length - 1) {

--- a/src/index-webworker.ts
+++ b/src/index-webworker.ts
@@ -158,7 +158,11 @@ const toA11yMessageJson = (message: A11Y_MESSAGE<Cell, GameSprite>): A11Y_MESSAG
         case A11Y_MESSAGE_TYPE.REMOVE:
             return { ...message, cell: toCellJson(message.cell), sprites: [...message.sprites].map(toSpriteName) }
         case A11Y_MESSAGE_TYPE.REPLACE:
-            return { ...message, cell: toCellJson(message.cell), replacements: [...message.replacements].map(({ oldSprite, newSprite }) =>({ oldSprite: toSpriteName(oldSprite), newSprite: toSpriteName(newSprite) })) }
+            return {
+                ...message,
+                cell: toCellJson(message.cell),
+                replacements: [...message.replacements].map(({ oldSprite, newSprite }) => ({ oldSprite: toSpriteName(oldSprite), newSprite: toSpriteName(newSprite) }))
+            }
     }
 }
 

--- a/src/ui/table.ts
+++ b/src/ui/table.ts
@@ -4,7 +4,18 @@ import { A11Y_MESSAGE, A11Y_MESSAGE_TYPE } from '../models/rule'
 import { GameSprite } from '../models/tile'
 import { Soundish } from '../parser/astTypes'
 import { playSound } from '../sound/sfxr'
-import { _flatten, Cellish, EmptyGameEngineHandler, GameEngineHandler, GameEngineHandlerOptional, INPUT_BUTTON, Optional, RULE_DIRECTION, setIntersection, spritesThatInteractWithPlayer } from '../util'
+import {
+    _flatten,
+    Cellish,
+    EmptyGameEngineHandler,
+    GameEngineHandler,
+    GameEngineHandlerOptional,
+    INPUT_BUTTON,
+    Optional,
+    RULE_DIRECTION,
+    setIntersection,
+    spritesThatInteractWithPlayer
+} from '../util'
 import BaseUI from './base'
 
 interface ITableCell {
@@ -14,8 +25,8 @@ interface ITableCell {
 }
 
 function mapIncrement<T>(map: Map<T, number>, item: T) {
-    const number = map.get(item)
-    map.set(item, number ? number + 1 : 1)
+    const num = map.get(item)
+    map.set(item, num ? num + 1 : 1)
 }
 
 class TableUI extends BaseUI implements GameEngineHandler {
@@ -51,7 +62,7 @@ class TableUI extends BaseUI implements GameEngineHandler {
 
         const liveLog = table.querySelector('[aria-live]') || document.querySelector('[aria-live]')
         if (!liveLog) {
-            throw new Error(`Error: For screenreaders to work, an element inside the table (for now) with an aria-live attribute needs to exist in the initial page. See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions`)
+            throw new Error(`Error: For screenreaders to work, an element inside the table (for now) with an aria-live attribute needs to exist in the initial page. See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions`) // tslint:disable-line:max-line-length
         }
         this.liveLog = liveLog
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -419,7 +419,9 @@ export class EmptyGameEngineHandler implements GameEngineHandler {
     public onLevelChange(level: number, cells: Optional<Cellish[][]>, message: Optional<string>) { for (const h of this.subHandlers) { h.onLevelChange && h.onLevelChange(level, cells, message) } }
     public onWin() { for (const h of this.subHandlers) { h.onWin && h.onWin() } }
     public async onSound(sound: Soundish) { for (const h of this.subHandlers) { h.onSound && h.onSound(sound) } }
-    public onTick(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>) { for (const h of this.subHandlers) { h.onTick && h.onTick(changedCells, hasAgain, a11yMessages) } }
+    public onTick(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>) {
+        for (const h of this.subHandlers) { h.onTick && h.onTick(changedCells, hasAgain, a11yMessages) }
+    }
     public onPause() { for (const h of this.subHandlers) { h.onPause && h.onPause() } }
     public onResume() { for (const h of this.subHandlers) { h.onResume && h.onResume() } }
     // public onGameChange(data: GameData) { this.subHandlers.forEach(h => h.onGameChange && h.onGameChange(data)) }

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,7 @@ import { GameMetadata } from './models/metadata'
 import { GameSprite } from './models/tile'
 import { Soundish } from './parser/astTypes'
 import { IGraphJson } from './parser/serializer'
+import { IMutation } from './models/rule';
 
 export type Optional<T> = T | null
 
@@ -387,7 +388,7 @@ export interface GameEngineHandler {
     onLevelChange(level: number, cells: Optional<Cellish[][]>, message: Optional<string>): void
     onWin(): void
     onSound(sound: Soundish): Promise<void>
-    onTick(changedCells: Set<Cellish>, hasAgain: boolean): void
+    onTick(changedCells: Set<Cellish>, hasAgain: boolean, mutations: Set<IMutation>): void
     onPause(): void
     onResume(): void
     // onGameChange(data: GameData): void
@@ -399,7 +400,7 @@ export interface GameEngineHandlerOptional {
     onLevelChange?(level: number, cells: Optional<Cellish[][]>, message: Optional<string>): void
     onWin?(): void
     onSound?(sound: Soundish): Promise<void>
-    onTick?(changedCells: Set<Cellish>, hasAgain: boolean): void
+    onTick?(changedCells: Set<Cellish>, hasAgain: boolean, mutations: Set<IMutation>): void
     onPause?(): void
     onResume?(): void
     // onGameChange?(data: GameData): void
@@ -415,7 +416,7 @@ export class EmptyGameEngineHandler implements GameEngineHandler {
     public onLevelChange(level: number, cells: Optional<Cellish[][]>, message: Optional<string>) { for (const h of this.subHandlers) { h.onLevelChange && h.onLevelChange(level, cells, message) } }
     public onWin() { for (const h of this.subHandlers) { h.onWin && h.onWin() } }
     public async onSound(sound: Soundish) { for (const h of this.subHandlers) { h.onSound && h.onSound(sound) } }
-    public onTick(changedCells: Set<Cellish>, hasAgain: boolean) { for (const h of this.subHandlers) { h.onTick && h.onTick(changedCells, hasAgain) } }
+    public onTick(changedCells: Set<Cellish>, hasAgain: boolean, mutations: Set<IMutation>) { for (const h of this.subHandlers) { h.onTick && h.onTick(changedCells, hasAgain, mutations) } }
     public onPause() { for (const h of this.subHandlers) { h.onPause && h.onPause() } }
     public onResume() { for (const h of this.subHandlers) { h.onResume && h.onResume() } }
     // public onGameChange(data: GameData) { this.subHandlers.forEach(h => h.onGameChange && h.onGameChange(data)) }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,10 @@
 import { GameData } from '.'
+import { Cell } from './engine'
 import { GameMetadata } from './models/metadata'
+import { A11Y_MESSAGE } from './models/rule'
 import { GameSprite } from './models/tile'
 import { Soundish } from './parser/astTypes'
 import { IGraphJson } from './parser/serializer'
-import { IMutation } from './models/rule';
 
 export type Optional<T> = T | null
 
@@ -295,7 +296,8 @@ export interface SerializedTickResult {
     messageToShow: Optional<string>
     didWinGame: boolean
     didLevelChange: boolean
-    wasAgainTick: boolean
+    wasAgainTick: boolean,
+    a11yMessages: A11Y_MESSAGE<CellishJson, string>
 }
 
 export type WorkerMessage = {
@@ -357,6 +359,7 @@ export type WorkerResponse = {
     type: MESSAGE_TYPE.ON_TICK
     changedCells: CellishJson[]
     hasAgain: boolean
+    a11yMessages: Array<A11Y_MESSAGE<CellishJson, string>>
 }
 
 export interface PuzzlescriptWorker {
@@ -388,7 +391,7 @@ export interface GameEngineHandler {
     onLevelChange(level: number, cells: Optional<Cellish[][]>, message: Optional<string>): void
     onWin(): void
     onSound(sound: Soundish): Promise<void>
-    onTick(changedCells: Set<Cellish>, hasAgain: boolean, mutations: Set<IMutation>): void
+    onTick(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cell, GameSprite>>): void
     onPause(): void
     onResume(): void
     // onGameChange(data: GameData): void
@@ -400,7 +403,7 @@ export interface GameEngineHandlerOptional {
     onLevelChange?(level: number, cells: Optional<Cellish[][]>, message: Optional<string>): void
     onWin?(): void
     onSound?(sound: Soundish): Promise<void>
-    onTick?(changedCells: Set<Cellish>, hasAgain: boolean, mutations: Set<IMutation>): void
+    onTick?(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>): void
     onPause?(): void
     onResume?(): void
     // onGameChange?(data: GameData): void
@@ -416,7 +419,7 @@ export class EmptyGameEngineHandler implements GameEngineHandler {
     public onLevelChange(level: number, cells: Optional<Cellish[][]>, message: Optional<string>) { for (const h of this.subHandlers) { h.onLevelChange && h.onLevelChange(level, cells, message) } }
     public onWin() { for (const h of this.subHandlers) { h.onWin && h.onWin() } }
     public async onSound(sound: Soundish) { for (const h of this.subHandlers) { h.onSound && h.onSound(sound) } }
-    public onTick(changedCells: Set<Cellish>, hasAgain: boolean, mutations: Set<IMutation>) { for (const h of this.subHandlers) { h.onTick && h.onTick(changedCells, hasAgain, mutations) } }
+    public onTick(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>) { for (const h of this.subHandlers) { h.onTick && h.onTick(changedCells, hasAgain, a11yMessages) } }
     public onPause() { for (const h of this.subHandlers) { h.onPause && h.onPause() } }
     public onResume() { for (const h of this.subHandlers) { h.onResume && h.onResume() } }
     // public onGameChange(data: GameData) { this.subHandlers.forEach(h => h.onGameChange && h.onGameChange(data)) }

--- a/style.css
+++ b/style.css
@@ -47,3 +47,16 @@ table.ps-table:not(.ps-ui-disabled) .ps-sprite-pixel { flex-grow: 1 }
 table.ps-table.ps-ui-disabled tr td.ps-cell .ps-cell-label.ps-cell-empty {
     opacity: .25;
 }
+
+table.ps-table.ps-ui-disabled caption {
+    caption-side: bottom;
+    text-align: left;
+    font-size: 50%;
+    opacity: .5;
+}
+
+table.ps-table:not(.ps-ui-disabled) caption,
+table.ps-table:not(.ps-ui-disabled) [aria-live] {
+    position: absolute;
+    left: -10000px;
+}

--- a/typings/contro.d.ts
+++ b/typings/contro.d.ts
@@ -4,8 +4,8 @@ declare module 'contro' {
   export function and<T1, T2 extends Control<T1>>(...controls: T2[]): T2
 
   interface Vector2 {
-    xAxis: number
-    yAxis: number
+    x: number
+    y: number
   }
 
   interface Control<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,9 +2156,9 @@ content-disposition@0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
   integrity sha1-DPaLud318r55YcOoUXjLhdunjLQ=
 
-"contro@github:philschatz/contro#3fb450c076262a3338535341550259c2f3391de7":
+"contro@github:philschatz/contro#51a450da7758f0754bed7d2248942a4557d112fc":
   version "0.0.0-semantically-released"
-  resolved "https://codeload.github.com/philschatz/contro/tar.gz/3fb450c076262a3338535341550259c2f3391de7"
+  resolved "https://codeload.github.com/philschatz/contro/tar.gz/51a450da7758f0754bed7d2248942a4557d112fc"
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.6.0"


### PR DESCRIPTION
This attaches to an `[aria-live]` element and appends messages of cells that changed so a non-sighted player can hear what changed in the game as they play. By default, the `[aria-live]` element is in the table `<caption>` but it could be anywhere on the page _as long as the element is available at initial page load_.

![aria-live](https://user-images.githubusercontent.com/253202/51067305-96e0a480-15d6-11e9-8a65-6469b9d0d4b5.gif)

# Naive Noise Detection

This also tries to detect when sprites are only used for animations and removes them:

![aria-live2](https://user-images.githubusercontent.com/253202/51067401-90066180-15d7-11e9-8cfa-ecd4d2051906.gif)
