### PR TITLE
use internal gamepad library

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "bitset": "^5.0.4",
     "chalk": "^2.4.1",
     "commander": "^2.19.0",
-    "contro": "github:philschatz/contro#51a450da7758f0754bed7d2248942a4557d112fc",
     "eventemitter2": "^5.0.1",
     "firstline": "^2.0.2",
     "font-ascii": "^1.1.16",

--- a/src/browser/controller/README.md
+++ b/src/browser/controller/README.md
@@ -84,10 +84,20 @@ const direction = stick.direction() // 'UP', 'DOWN', ..., or null . The cardinal
 
 Keyboard keys can also be handled like gamepad buttons.
 
+Optionally, a scope element can/should be specified so keys on the whole webpage still work.
+
 ```ts
 const button2 = Controllers.key('Enter')
 const isPressed = button2.query()
 button2.dispose()
+```
+
+Optional scope and modifier keys.
+For example, to check if <kbd>Shift</kbd>+<kbd>S</kbd> when the game is focused on, use the following:
+
+```ts
+const button3 = Controllers.key('s', gameEl, [ KEY_MODIFIER.SHIFT ])
+button3.query() // true if Shift+S is pressed while `gameEl` is the focused element.
 ```
 
 ## Composition

--- a/src/browser/controller/README.md
+++ b/src/browser/controller/README.md
@@ -1,0 +1,120 @@
+# Usage
+
+This library is inspired by [contro](https://npm.im/contro) but has a few different features:
+
+- uses the [standard](https://w3c.github.io/gamepad/#dfn-standard-gamepad-layout) layout to refer to buttons and sticks
+- supports gamepads that do not use the `standard` layout 
+  - some browsers like Firefox do not provide a standard mapping
+  - uses [mapping files](./configs/) to support non-standard gamepads
+- allows checking if a specific button is available on the gamepad
+- allows composing buttons, sticks, and even gamepads to make it easier to write games
+- allows disposing of keyboard buttons
+
+## Example
+
+This example shows how to set controls for a simple single-player platformer.
+
+```ts
+import { Controllers, BUTTON_TYPE, DIRECTION, dpadAsStick } from './controller'
+
+const pad = Controllers.getAnyGamepad()
+const stick = dpadAsStick(pad)
+const jumpButton = pad.button(BUTTON_TYPE.CLUSTER_BOTTOM)
+
+function loop() {
+
+    if (stick.direction() === DIRECTION.RIGHT) {
+        // move right...
+    }
+    if (jumpButton.query()) {
+        // jump...
+    }
+
+    if (pad.isConnected()) {
+        console.log('The gamepad is connected!')
+    }
+}
+```
+
+## API
+
+Here are all of the importable things (excluding interfaces)
+
+```ts
+import {
+    Controllers,
+    BUTTON_TYPE,
+    STICK_TYPE,
+    dpadAsStick,
+    wsadKeysAsStick,
+    arrowKeysAsStick,
+} from './controller'
+```
+
+## Get gamepads
+
+These methods allow getting a specific gamepad, an array of gamepads (some of which are null), or an AnyGamepad which is like or'ing all of the gamepads together if your game does not care about multiple gamepads.
+
+```ts
+const gamepad = Controllers.getAnyGamepad()
+const gamepad2 = Controllers.getGamepad(2)
+const gamepads = Controllers.getGamepads()
+```
+
+## Check the state
+
+```ts
+gamepad.isConnected()
+gamepad.hasButton(BUTTON_TYPE.ARROW_LEFT)
+gamepad.hasStick(STICK_TYPE.LEFT)
+
+const button = gamepad.button(BUTTON_TYPE.ARROW_LEFT)
+const stick = gamepad.stick(STICK_TYPE.LEFT)
+
+// Not all controllers have the same buttons so there is a handy `.has()`
+button.has() // Check if this button is available on the gamepad
+stick.has()  // Check if this stick  is available on the gamepad
+
+const isPressed = button.query() // `false` when not available so use `.has()` to check
+const {x, y} = stick.query()     // `{x:0, y:0}` when not available so use `.has()` to check
+const direction = stick.direction() // 'UP', 'DOWN', ..., or null . The cardinal stick direction
+```
+
+## Keyboard handling
+
+Keyboard keys can also be handled like gamepad buttons.
+
+```ts
+const button2 = Controllers.key('Enter')
+const isPressed = button2.query()
+button2.dispose()
+```
+
+## Composition
+
+You can compose buttons together, buttons into a stick, sticks together, or all of the controllers into one.
+
+```ts
+// Combine multiple buttons
+const composite = Controllers.or([button, button2])
+
+// Construct a dpad using the controller OR the wsad keys
+const dpad = Controllers.asStick(
+    Controllers.or([gamepad.button(BUTTON_TYPE.ARROW_UP), Controllers.key('w')]),
+    Controllers.or([gamepad.button(BUTTON_TYPE.ARROW_DOWN), Controllers.key('s')]),
+    Controllers.or([gamepad.button(BUTTON_TYPE.ARROW_LEFT), Controllers.key('a')]),
+    Controllers.or([gamepad.button(BUTTON_TYPE.ARROW_RIGHT), Controllers.key('d')]),
+)
+
+// Or, use one of the pre-created ones:
+const dpadStick = dpadAsStick(gamepad)
+const wsadStick = wsadKeyAsStick()
+const arrowStick = arrowKeysAsStick()
+
+// Combine multiple sticks (which could be buttons)
+const megaStick = Controllers.orStick([dpadStick, wsadStick, arrowStick])
+
+// Combine all the gamepads into one
+const any = Controllers.getAnyGamepad()
+```
+

--- a/src/browser/controller/configs/index.ts
+++ b/src/browser/controller/configs/index.ts
@@ -1,0 +1,63 @@
+/* Mappings for all supported controllers.
+ * To add a new controller, add a new JSON file and update the `controllerConfigs` below.
+ * https://html5gamepad.com/ can be helpful for getting the values.
+ */
+import c0 from './n64-retrolink'
+import c1 from './ps3'
+import c2 from './ps4'
+import standard from './standard'
+import c3 from './xbox'
+
+const controllerConfigs = [
+    // These are ordered by popularity
+    standard,
+    c2,
+    c3,
+    c0,
+    c1
+]
+
+export interface StickIndexes {
+    xAxis: number
+    yAxis: number
+}
+
+export interface GamepadMapping {
+    id: string
+    buttons: {
+        ARROW_UP?: number
+        ARROW_DOWN?: number
+        ARROW_LEFT?: number
+        ARROW_RIGHT?: number
+        HOME?: number
+        START?: number
+        SELECT?: number
+        CLUSTER_TOP?: number
+        CLUSTER_LEFT?: number
+        CLUSTER_RIGHT?: number
+        CLUSTER_BOTTOM?: number
+        BUMPER_TOP_LEFT?: number
+        BUMPER_BOTTOM_LEFT?: number
+        BUMPER_TOP_RIGHT?: number
+        BUMPER_BOTTOM_RIGHT?: number
+        STICK_PRESS_LEFT?: number
+        STICK_PRESS_RIGHT?: number
+        TOUCHSCREEN?: number
+    },
+    sticks: {
+        LEFT?: StickIndexes
+        RIGHT?: StickIndexes
+    },
+    analogs: {
+        BUMPER_LEFT?: number
+        BUMPER_RIGHT?: number
+    }
+}
+
+export function getGamepadConfig(gamepad: Gamepad) {
+    if (gamepad.mapping === 'standard') {
+        return standard
+    } else {
+        return controllerConfigs.find((c) => gamepad.id === c.id) || null
+    }
+}

--- a/src/browser/controller/configs/n64-retrolink.ts
+++ b/src/browser/controller/configs/n64-retrolink.ts
@@ -1,0 +1,31 @@
+import { GamepadMapping } from '.'
+
+const config: GamepadMapping = {
+    id: '79-6-Generic   USB  Joystick  ',
+    buttons: {
+        ARROW_UP: 12,
+        ARROW_DOWN: 13,
+        ARROW_LEFT: 14,
+        ARROW_RIGHT: 15,
+        // HOME
+        START: 9,
+        // SELECT
+        CLUSTER_TOP: 3,
+        CLUSTER_LEFT: 8,
+        CLUSTER_RIGHT: 2,
+        CLUSTER_BOTTOM: 6,
+        BUMPER_TOP_LEFT: 4,
+        BUMPER_BOTTOM_LEFT: 7,
+        BUMPER_TOP_RIGHT: 5,
+        // BUMPER_BOTTOM_RIGHT
+        STICK_PRESS_LEFT: 0,
+        STICK_PRESS_RIGHT: 1
+    },
+    sticks: {
+        LEFT: { xAxis: 1, yAxis: 2 }
+        // RIGHT
+    },
+    analogs: {}
+}
+
+export default config

--- a/src/browser/controller/configs/ps3.ts
+++ b/src/browser/controller/configs/ps3.ts
@@ -1,0 +1,31 @@
+import { GamepadMapping } from '.'
+
+const config: GamepadMapping = {
+    id: '54c-268-PLAYSTATION(R)3 Controller',
+    buttons: {
+        ARROW_UP: 4,
+        ARROW_DOWN: 6,
+        ARROW_LEFT: 7,
+        ARROW_RIGHT: 5,
+        HOME: 16,
+        START: 3,
+        SELECT: 0,
+        CLUSTER_TOP: 12,
+        CLUSTER_LEFT: 15,
+        CLUSTER_RIGHT: 13,
+        CLUSTER_BOTTOM: 14,
+        BUMPER_TOP_LEFT: 10,
+        BUMPER_BOTTOM_LEFT: 8,
+        BUMPER_TOP_RIGHT: 11,
+        BUMPER_BOTTOM_RIGHT: 9,
+        STICK_PRESS_LEFT: 1,
+        STICK_PRESS_RIGHT: 2
+    },
+    sticks: {
+        LEFT: { xAxis: 0, yAxis: 1 },
+        RIGHT: { xAxis: 2, yAxis: 3 }
+    },
+    analogs: {}
+}
+
+export default config

--- a/src/browser/controller/configs/ps4.ts
+++ b/src/browser/controller/configs/ps4.ts
@@ -1,0 +1,35 @@
+import { GamepadMapping } from '.'
+
+const config: GamepadMapping = {
+    id: '54c-9cc-Wireless Controller',
+    buttons: {
+        ARROW_UP: 14,
+        ARROW_DOWN: 15,
+        ARROW_LEFT: 16,
+        ARROW_RIGHT: 17,
+        HOME: 12,
+        START: 9,
+        SELECT: 8,
+        CLUSTER_TOP: 3,
+        CLUSTER_LEFT: 0,
+        CLUSTER_RIGHT: 2,
+        CLUSTER_BOTTOM: 1,
+        BUMPER_TOP_LEFT: 4,
+        BUMPER_BOTTOM_LEFT: 6,
+        BUMPER_TOP_RIGHT: 5,
+        BUMPER_BOTTOM_RIGHT: 7,
+        STICK_PRESS_LEFT: 10,
+        STICK_PRESS_RIGHT: 11,
+        TOUCHSCREEN: 13
+    },
+    sticks: {
+        LEFT: { xAxis: 0, yAxis: 1 },
+        RIGHT: { xAxis: 2, yAxis: 5 }
+    },
+    analogs: {
+        BUMPER_LEFT: 3,
+        BUMPER_RIGHT: 4
+    }
+}
+
+export default config

--- a/src/browser/controller/configs/standard.ts
+++ b/src/browser/controller/configs/standard.ts
@@ -1,0 +1,31 @@
+import { GamepadMapping } from '.'
+
+const config: GamepadMapping = {
+    id: 'Wireless Controller (STANDARD GAMEPAD)',
+    buttons: {
+        ARROW_UP: 12,
+        ARROW_DOWN: 13,
+        ARROW_LEFT: 14,
+        ARROW_RIGHT: 15,
+        HOME: 16,
+        START: 9,
+        SELECT: 8,
+        CLUSTER_TOP: 3,
+        CLUSTER_LEFT: 2,
+        CLUSTER_RIGHT: 1,
+        CLUSTER_BOTTOM: 0,
+        BUMPER_TOP_LEFT: 4,
+        BUMPER_BOTTOM_LEFT: 6,
+        BUMPER_TOP_RIGHT: 5,
+        BUMPER_BOTTOM_RIGHT: 7,
+        STICK_PRESS_LEFT: 10,
+        STICK_PRESS_RIGHT: 11
+    },
+    sticks: {
+        LEFT: { xAxis: 0, yAxis: 1 },
+        RIGHT: { xAxis: 2, yAxis: 3 }
+    },
+    analogs: {}
+}
+
+export default config

--- a/src/browser/controller/configs/xbox.ts
+++ b/src/browser/controller/configs/xbox.ts
@@ -1,0 +1,31 @@
+import { GamepadMapping } from '.'
+
+const config: GamepadMapping = {
+    id: '[temp xbox id]',
+    buttons: {
+        ARROW_UP: 12,
+        ARROW_DOWN: 13,
+        ARROW_LEFT: 14,
+        ARROW_RIGHT: 15,
+        HOME: 16,
+        START: 9,
+        SELECT: 8,
+        CLUSTER_TOP: 3,
+        CLUSTER_LEFT: 2,
+        CLUSTER_RIGHT: 1,
+        CLUSTER_BOTTOM: 0,
+        BUMPER_TOP_LEFT: 4,
+        BUMPER_BOTTOM_LEFT: 6,
+        BUMPER_TOP_RIGHT: 5,
+        BUMPER_BOTTOM_RIGHT: 7,
+        STICK_PRESS_LEFT: 10,
+        STICK_PRESS_RIGHT: 11
+    },
+    sticks: {
+        LEFT: { xAxis: 0, yAxis: 1 },
+        RIGHT: { xAxis: 2, yAxis: 3 }
+    },
+    analogs: {}
+}
+
+export default config

--- a/src/browser/controller/controller.ts
+++ b/src/browser/controller/controller.ts
@@ -1,0 +1,327 @@
+import { getGamepadConfig } from './configs'
+
+export enum BUTTON_TYPE {
+    ARROW_UP = 'ARROW_UP',
+    ARROW_DOWN = 'ARROW_DOWN',
+    ARROW_LEFT = 'ARROW_LEFT',
+    ARROW_RIGHT = 'ARROW_RIGHT',
+    HOME = 'HOME',
+    START = 'START',
+    SELECT = 'SELECT',
+    CLUSTER_TOP = 'CLUSTER_TOP',
+    CLUSTER_LEFT = 'CLUSTER_LEFT',
+    CLUSTER_RIGHT = 'CLUSTER_RIGHT',
+    CLUSTER_BOTTOM = 'CLUSTER_BOTTOM',
+    BUMPER_TOP_LEFT = 'BUMPER_TOP_LEFT',
+    BUMPER_BOTTOM_LEFT = 'BUMPER_BOTTOM_LEFT',
+    BUMPER_TOP_RIGHT = 'BUMPER_TOP_RIGHT',
+    BUMPER_BOTTOM_RIGHT = 'BUMPER_BOTTOM_RIGHT',
+    STICK_PRESS_LEFT = 'STICK_PRESS_LEFT',
+    STICK_PRESS_RIGHT = 'STICK_PRESS_RIGHT',
+    TOUCHSCREEN = 'TOUCHSCREEN'
+}
+export enum STICK_TYPE {
+    LEFT = 'LEFT',
+    RIGHT = 'RIGHT'
+}
+export enum ANALOG_TYPE {
+    BUMPER_LEFT = 'BUMPER_LEFT',
+    BUMPER_RIGHT = 'BUMPER_RIGHT'
+}
+
+export enum DIRECTION {
+    UP = 'UP',
+    DOWN = 'DOWN',
+    LEFT = 'LEFT',
+    RIGHT = 'RIGHT'
+}
+
+export interface IGamepad {
+    isConnected(): boolean
+    hasButton(arg: BUTTON_TYPE): boolean
+    hasStick(arg: STICK_TYPE): boolean
+    isButtonPressed(arg: BUTTON_TYPE): boolean
+    getStickValue(arg: STICK_TYPE): IVector
+    getStickDirection(arg: STICK_TYPE): DIRECTION | null
+    button(arg: BUTTON_TYPE): IButton
+    stick(arg: STICK_TYPE): IStick
+}
+
+export interface IButton {
+    has(): boolean
+    query(): boolean
+}
+
+export interface IKeyboardButton extends IButton {
+    dispose(): void
+}
+
+export interface IStick {
+    has(): boolean
+    query(): IVector
+    direction(): DIRECTION | null
+}
+
+export interface IVector {
+    x: number
+    y: number
+}
+
+function lookupButtonIndex(gamepad: Gamepad, arg: BUTTON_TYPE) {
+    const config = getGamepadConfig(gamepad)
+    // little more complicated because the index could be 0
+    if (config) {
+        if (typeof config.buttons[arg] !== 'undefined') {
+            return config.buttons[arg] || null
+        }
+    }
+    return null
+}
+
+function lookupStickIndex(gamepad: Gamepad, arg: STICK_TYPE) {
+    const config = getGamepadConfig(gamepad)
+    return config && config.sticks[arg] || null
+}
+
+class ControllerGamepad implements IGamepad {
+    private readonly index: number
+    constructor(index: number) {
+        if (!(index >= 0)) {
+            throw new Error(`Must provide an index. Or, use the AnyGamepad class`)
+        }
+        this.index = index
+    }
+    public isConnected() {
+        return !!this.raw()
+    }
+    public isButtonPressed(arg: BUTTON_TYPE) {
+        const raw = this.raw()
+        if (raw) {
+            const index = this.buttonIndex(arg)
+            return index !== null && raw.buttons[index].pressed
+        } else {
+            return false
+        }
+    }
+    public hasButton(arg: BUTTON_TYPE) {
+        return this.buttonIndex(arg) !== null
+    }
+    public button(arg: BUTTON_TYPE): IButton {
+        return {
+            has: () => this.hasButton(arg),
+            query: () => this.isButtonPressed(arg)
+        }
+    }
+    public getStickValue(arg: STICK_TYPE): IVector {
+        const raw = this.raw()
+        if (raw) {
+            const indexes = this.stickIndex(arg)
+            if (indexes) {
+                const { xAxis, yAxis } = indexes
+                return { x: raw.axes[xAxis], y: raw.axes[yAxis] }
+            }
+        }
+        return { x: 0, y: 0 }
+    }
+    public getStickDirection(arg: STICK_TYPE) {
+        const { x, y } = this.getStickValue(arg)
+        const xAbs = Math.abs(x)
+        const yAbs = Math.abs(y)
+        if (xAbs < .5 && yAbs < .5) { return null } else if (xAbs > yAbs) { return x > 0 ? DIRECTION.LEFT : DIRECTION.RIGHT } else { return y > 0 ? DIRECTION.DOWN : DIRECTION.UP }
+    }
+    public hasStick(arg: STICK_TYPE) {
+        return this.stickIndex(arg) !== null
+    }
+    public stick(arg: STICK_TYPE): IStick {
+        return {
+            has: () => this.hasStick(arg),
+            query: () => this.getStickValue(arg),
+            direction: () => this.getStickDirection(arg)
+        }
+    }
+    private raw() {
+        return [...navigator.getGamepads()][this.index] || null
+    }
+    private buttonIndex(arg: BUTTON_TYPE) {
+        const raw = this.raw()
+        return raw && lookupButtonIndex(raw, arg)
+    }
+    private stickIndex(arg: STICK_TYPE) {
+        const raw = this.raw()
+        return raw && lookupStickIndex(raw, arg)
+    }
+}
+
+class AnyGamepad implements IGamepad {
+    public isConnected() {
+        return !!Controllers.getGamepads().find((c) => !!c && c.isConnected())
+    }
+    public hasButton(arg: BUTTON_TYPE) {
+        return !!Controllers.getGamepads().find((c) => !!c && c.hasButton(arg))
+    }
+    public isButtonPressed(arg: BUTTON_TYPE) {
+        for (const c of Controllers.getGamepads()) {
+            if (c && c.isButtonPressed(arg)) {
+                return true
+            }
+        }
+        return false
+    }
+    public button(arg: BUTTON_TYPE): IButton {
+        return {
+            has: () => this.hasButton(arg),
+            query: () => this.isButtonPressed(arg)
+        }
+    }
+    public hasStick(arg: STICK_TYPE) {
+        return !!Controllers.getGamepads().find((c) => !!c && c.hasStick(arg))
+    }
+    public getStickValue(arg: STICK_TYPE) {
+        let xSum = 0
+        let ySum = 0
+        for (const c of Controllers.getGamepads()) {
+            if (c) {
+                const { x, y } = c.getStickValue(arg)
+                xSum += x
+                ySum += y
+            }
+        }
+        return { x: xSum, y: ySum }
+    }
+    public getStickDirection(arg: STICK_TYPE) {
+        const gamepad = Controllers.getGamepads().find((c) => !!c && c.getStickDirection(arg) !== null) || null
+        return gamepad && gamepad.getStickDirection(arg)
+    }
+    public stick(arg: STICK_TYPE): IStick {
+        return {
+            has: () => this.hasStick(arg),
+            query: () => this.getStickValue(arg),
+            direction: () => this.getStickDirection(arg)
+        }
+    }
+}
+
+export const Controllers = new (class ControllersSingleton {
+    private readonly cache: IGamepad[]
+    private any: IGamepad | null
+    constructor() {
+        this.cache = []
+        this.any = null
+    }
+    public getGamepads() {
+        return [...navigator.getGamepads()].map((raw, index) => raw && this.getGamepad(index))
+    }
+    public getGamepad(index: number) {
+        this.cache[index] = this.cache[index] || new ControllerGamepad(index)
+        return this.cache[index]
+    }
+    public getAnyGamepad() {
+        if (this.any) {
+            return this.any
+        }
+        const anyGamepad = new AnyGamepad()
+        this.any = anyGamepad
+        return anyGamepad
+    }
+
+    public key(key: string): IKeyboardButton {
+        let pressed = false
+        const onKeyDown = (evt: KeyboardEvent) => {
+            if (evt.key === key) { pressed = true }
+        }
+        const onKeyUp = (evt: KeyboardEvent) => {
+            if (evt.key === key) { pressed = false }
+        }
+        window.addEventListener('keydown', onKeyDown)
+        window.addEventListener('keyup', onKeyUp)
+        return {
+            has() { return true },
+            query: () => pressed,
+            dispose: () => {
+                window.removeEventListener('keydown', onKeyDown)
+                window.removeEventListener('keyup', onKeyUp)
+            }
+        }
+    }
+
+    public or(arg: IButton[]): IButton {
+        return {
+            has() { return !!arg.find((b) => b.has()) },
+            query() { return !!arg.find((b) => b.query()) }
+        }
+    }
+
+    public asStick(up: IButton, down: IButton, left: IButton, right: IButton): IStick {
+        function query() {
+            const u = up.query()
+            const d = down.query()
+            const l = left.query()
+            const r = right.query()
+            const x = 0 + (u ? -1 : 0) + (d ? 1 : 0)
+            const y = 0 + (l ? -1 : 0) + (r ? 1 : 0)
+            return { x, y }
+        }
+        return {
+            query,
+            has() {
+                return up.has() && down.has() && left.has() && right.has()
+            },
+            direction() {
+                const { x, y } = query()
+                if (x < 0 && y === 0) { return DIRECTION.UP }
+                if (x > 0 && y === 0) { return DIRECTION.DOWN }
+                if (y < 0 && x === 0) { return DIRECTION.LEFT }
+                if (y > 0 && x === 0) { return DIRECTION.RIGHT }
+                return null
+            }
+        }
+    }
+
+    public orSticks(arg: IStick[]): IStick {
+        function query() {
+            let xSum = 0
+            let ySum = 0
+            for (const stick of arg) {
+                const { x, y } = stick.query()
+                xSum += x
+                ySum += y
+            }
+            return { x: xSum, y: ySum }
+        }
+        return {
+            query,
+            has() {
+                return !!arg.find((c) => c.has())
+            },
+            direction() {
+                const { x, y } = query()
+                if (x < 0 && y === 0) { return DIRECTION.UP }
+                if (x > 0 && y === 0) { return DIRECTION.DOWN }
+                if (y < 0 && x === 0) { return DIRECTION.LEFT }
+                if (y > 0 && x === 0) { return DIRECTION.RIGHT }
+                return null
+            }
+        }
+    }
+})() // new Singleton
+
+export const arrowKeysAsStick = () => Controllers.asStick(
+    Controllers.key('ArrowUp'),
+    Controllers.key('ArrowDown'),
+    Controllers.key('ArrowLeft'),
+    Controllers.key('ArrowRight')
+)
+
+export const wsadKeysAsStick = () => Controllers.asStick(
+    Controllers.key('w'),
+    Controllers.key('s'),
+    Controllers.key('a'),
+    Controllers.key('d')
+)
+
+export const dpadAsStick = (arg: IGamepad) => Controllers.asStick(
+    arg.button(BUTTON_TYPE.ARROW_UP),
+    arg.button(BUTTON_TYPE.ARROW_DOWN),
+    arg.button(BUTTON_TYPE.ARROW_LEFT),
+    arg.button(BUTTON_TYPE.ARROW_RIGHT)
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,10 +2156,6 @@ content-disposition@0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
   integrity sha1-DPaLud318r55YcOoUXjLhdunjLQ=
 
-"contro@github:philschatz/contro#51a450da7758f0754bed7d2248942a4557d112fc":
-  version "0.0.0-semantically-released"
-  resolved "https://codeload.github.com/philschatz/contro/tar.gz/51a450da7758f0754bed7d2248942a4557d112fc"
-
 convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"


### PR DESCRIPTION
This adds an internal gamepad library similar to [contro](https://npm.im/contro) but provides the following features:

- [x] uses the **[standard](https://w3c.github.io/gamepad/#dfn-standard-gamepad-layout) layout** to refer to buttons and sticks
- [x] supports gamepads that do not use the `standard` layout 
  - some browsers like Firefox do not provide a standard mapping
  - uses **mapping files** to support non-standard gamepads
- [x] allows checking if a specific **button is available** on the gamepad
- [x] allows **composing** buttons, sticks, and even gamepads to make it easier to write games
- [x] allows **scoping the key presses** so they only apply when the game is in focus (being played)
- [x] allows **disposing** of keyboard buttons when they are no longer needed