### PR TITLE
add basic mobile touch support

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -2,6 +2,7 @@
 
 <head>
     <title>Example Puzzlescript Games using HTML Tables</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <script src="./lib/puzzlescript.js"></script>
     <link rel="stylesheet" href="./style.css"/>
     <style>


### PR DESCRIPTION
Adds some basic touch support for mobile devices.

To play:

- Swipe up/down/left/right on the game to move
- Tap to perform the action
- Hold for a second to undo/restart
  - this will pop up a confirm dialog which is annoying. Holding should undo and letting go should maybe ask if you want to restart