### PR TITLE
Play cached games

### DIFF
--- a/index.xhtml
+++ b/index.xhtml
@@ -163,9 +163,9 @@
             gameSelection.setAttribute('disabled', 'disabled')
 
             gameId = gameSelection.value
-            fetch(`./games/${gameId}/script.txt`)
+            fetch(`./games/${gameId}/script.txt`, {cache: 'force-cache'})
             .then(resp => {
-                if (resp.status === 200) {
+                if (resp.ok) {
                     return resp.text().then(function(source) {
                         // Load the game
                         tableEngine.setGame(source, getStorage(gameId) || 0)
@@ -176,6 +176,8 @@
                 }
             })
         }
+
+        
 
 
         // gh-pages does not allow hosting large JavaScript files so we need to load the webworker from unpkg.com
@@ -216,12 +218,13 @@
 
         // See https://gist.github.com/willywongi/5780151#file-2-index-html-L86
         function loadRemoteWebworker(webworkerUrl, callback) {
-            const oReq = new XMLHttpRequest();
-            oReq.addEventListener('load', function() {
-                callback(window.URL.createObjectURL(new Blob([this.responseText])))
-            }, oReq)
-            oReq.open('get', webworkerUrl, true)
-            oReq.send()
+            return fetch(webworkerUrl, {cache: 'force-cache'})
+            .then(function (resp) {
+                return resp.text()
+                .then(function (source) {
+                    callback(window.URL.createObjectURL(new Blob([this.responseText])))
+                })
+            })
         }
         
         // Functions for loading/saving game progress

--- a/index.xhtml
+++ b/index.xhtml
@@ -158,12 +158,59 @@
             gameSelection.addEventListener('change', function () { playSelectedGame(tableEngine)})
         }
 
+
+        let cacheApi
+        if (window.caches) {
+            cacheApi = window.caches
+        } else {
+            // In-memory polyfill for browsers that do not support https://developer.mozilla.org/en-US/docs/Web/API/Cache
+            const memCaches = new Map()
+            class InMemoryCache {
+                constructor() { this.map = new Map() }
+                put(request, response) { this.map.set(request.url, response.clone()) }
+                match(request) { return this.map.get(request.url) }
+            }
+            cacheApi = {
+                open: function (cacheName) {
+                    let ret = memCaches.get(cacheName) || new InMemoryCache()
+                    memCaches.add(ret)
+                    return Promise.resolve(ret)
+                }
+            }
+        }
+
+        // From https://stackoverflow.com/a/39367408
+        const CACHE_NAME = 'puzzlescript'
+        function cacheFetch(url, options) {
+            const request = new Request(url, options)
+            const requestURL = new URL(request.url)
+            const freshResource = fetch(request).then(function (response) {
+                const clonedResponse = response.clone()
+                // Don't update the cache with error pages!
+                if (response.ok) {
+                    // All good? Update the cache with the network response
+                    caches.open(CACHE_NAME).then(function (cache) {
+                        cache.put(request, clonedResponse)
+                    })
+                }
+                return response
+            })
+            const cachedResource = caches.open(CACHE_NAME).then(function (cache) {
+                return cache.match(request).then(function(response) {
+                    return response || freshResource
+                })
+            }).catch(function (e) {
+                return freshResource
+            })
+            return cachedResource
+        }
+
         function playSelectedGame(tableEngine) {
             loadingIndicator.classList.remove('hidden') // Show the "Loading..." text
             gameSelection.setAttribute('disabled', 'disabled')
 
             gameId = gameSelection.value
-            fetch(`./games/${gameId}/script.txt`, {cache: 'force-cache'})
+            cacheFetch(`./games/${gameId}/script.txt`, {redirect: 'follow'})
             .then(resp => {
                 if (resp.ok) {
                     return resp.text().then(function(source) {
@@ -172,8 +219,14 @@
                     })
                 } else {
                     alert('Problem finding game game file. Please choose another one')
+                    loadingIndicator.classList.add('hidden')
                     gameSelection.removeAttribute('disabled')
                 }
+            },
+            err => {
+                alert('Could not download the game. Are you connected to the internet?')
+                loadingIndicator.classList.add('hidden')
+                gameSelection.removeAttribute('disabled')
             })
         }
 
@@ -218,7 +271,7 @@
 
         // See https://gist.github.com/willywongi/5780151#file-2-index-html-L86
         function loadRemoteWebworker(webworkerUrl, callback) {
-            return fetch(webworkerUrl, {cache: 'force-cache'})
+            return cacheFetch(webworkerUrl, {redirect: 'follow'})
             .then(function (resp) {
                 return resp.text()
                 .then(function (source) {

--- a/index.xhtml
+++ b/index.xhtml
@@ -168,12 +168,19 @@
             class InMemoryCache {
                 constructor() { this.map = new Map() }
                 put(request, response) { this.map.set(request.url, response.clone()) }
-                match(request) { return this.map.get(request.url) }
+                match(request) { 
+                    const ret = this.map.get(request.url)
+                    if (ret) {
+                        return Promise.resolve(ret.clone())
+                    } else {
+                        return Promise.reject(`Cache miss for ${request.url}`)
+                    }
+                }
             }
             cacheApi = {
                 open: function (cacheName) {
                     let ret = memCaches.get(cacheName) || new InMemoryCache()
-                    memCaches.add(ret)
+                    memCaches.set(cacheName, ret)
                     return Promise.resolve(ret)
                 }
             }
@@ -189,13 +196,13 @@
                 // Don't update the cache with error pages!
                 if (response.ok) {
                     // All good? Update the cache with the network response
-                    caches.open(CACHE_NAME).then(function (cache) {
+                    cacheApi.open(CACHE_NAME).then(function (cache) {
                         cache.put(request, clonedResponse)
                     })
                 }
                 return response
             })
-            const cachedResource = caches.open(CACHE_NAME).then(function (cache) {
+            const cachedResource = cacheApi.open(CACHE_NAME).then(function (cache) {
                 return cache.match(request).then(function(response) {
                     return response || freshResource
                 })
@@ -275,7 +282,7 @@
             .then(function (resp) {
                 return resp.text()
                 .then(function (source) {
-                    callback(window.URL.createObjectURL(new Blob([this.responseText])))
+                    callback(window.URL.createObjectURL(new Blob([source])))
                 })
             })
         }


### PR DESCRIPTION
When hopping on a bus (or boarding a flight) it would be nice to pre-load some games, turn off the internet, and still be able to switch games.

This adds support for that use case.