### PR TITLE
make notifications optional

### DIFF
--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -69,31 +69,37 @@ window.addEventListener('load', () => {
                 ]
             }
             return new Promise((resolve) => {
-                Notification.requestPermission(async(result) => { // tslint:disable-line:no-floating-promises
-                    // Safari does not support registration.showNotification() so we fall back to new Notification()
-                    const fallback = () => {
-                        new Notification('Annoying Test Message', notificationOptions) // tslint:disable-line:no-unused-expression
-                        resolve()
-                    }
-                    if (result === 'granted') {
-                        if (navigator.serviceWorker) {
-                            // Mobile notification (Android Chrome)
-                            const registration = await navigator.serviceWorker.ready
-                            if (registration.showNotification) {
-                                await registration.showNotification('Annoying Test Message', notificationOptions)
-                                resolve()
+                // Notification is not available on iOS 
+                if (typeof Notification !== 'undefined') { // tslint:disable-line:strict-type-predicates
+                    Notification.requestPermission(async(result) => { // tslint:disable-line:no-floating-promises
+                        // Safari does not support registration.showNotification() so we fall back to new Notification()
+                        const fallback = () => {
+                            new Notification('Annoying Test Message', notificationOptions) // tslint:disable-line:no-unused-expression
+                            resolve()
+                        }
+                        if (result === 'granted') {
+                            if (navigator.serviceWorker) {
+                                // Mobile notification (Android Chrome)
+                                const registration = await navigator.serviceWorker.ready
+                                if (registration.showNotification) {
+                                    await registration.showNotification('Annoying Test Message', notificationOptions)
+                                    resolve()
+                                } else {
+                                    fallback()
+                                }
                             } else {
+                                // Desktop notification Fallback (Firefox)
                                 fallback()
                             }
                         } else {
-                            // Desktop notification Fallback (Firefox)
-                            fallback()
+                            alert(msg)
+                            resolve()
                         }
-                    } else {
-                        alert(msg)
-                        resolve()
-                    }
-                })
+                    })
+                } else {
+                    alert(msg)
+                    resolve()
+                }
             })
         },
         onLevelChange(newLevelNum) {


### PR DESCRIPTION
iOS does not support `Notification` and silently errors. This change makes it show an `alert()` instead