### PR TITLE
Use HTML dialog element instead of alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "babel-loader": "^8.0.4",
     "babel-polyfill": "^6.26.0",
     "codecov": "^3.1.0",
+    "dialog-polyfill": "^0.4.10",
     "html-webpack-plugin": "^3.2.0",
     "istanbul": "^0.4.5",
     "javascript-time-ago": "^2.0.1",

--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -57,6 +57,21 @@
             opacity: .5;
         }
 
+        /* Style the message dialog */
+        dialog {
+            border-radius: 6px;
+            /* border: 1px solid rgba(0, 0, 0, 0.3); */
+            /* box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3); */
+        }
+        dialog::backdrop,
+        dialog + .backdrop {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: rgba(0, 0, 0, 0.8);
+        }
     </style>
 
     <meta charset="utf-8"/>
@@ -72,6 +87,11 @@
 </head>
 
 <body>
+    <dialog id="messageDialog">
+        <p id="messageDialogText"></p>
+        <button id="messageDialogClose" title="Close this window">Close</button>
+    </dialog>
+        
     <h1 id="headingSection">Example <a href="https://github.com/philschatz/puzzlescript">PuzzleScript Games</a> using HTML Tables</h1>
 
     <p id="disableCssSection"><input id="disableCss" type="checkbox"/> <label for="disableCss"><strong>Check</strong> to see what a non-sighted user would experience (disables CSS)</label></p>

--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -169,7 +169,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-48498113-1', 'philschatz.com');
+        ga('create', 'UA-48498113-4', 'philschatz.com');
         ga('send', 'pageview');
 
         // Try to signal to Chrome that we are looking to use the real gamepad, not just up/down/left/right arrow keys mapped from a gamepad

--- a/src/browser/play.browser.spec.ts
+++ b/src/browser/play.browser.spec.ts
@@ -3,7 +3,7 @@
 import fs from 'fs'
 import path from 'path'
 import puppeteer from 'puppeteer' // tslint:disable-line:no-implicit-dependencies
-import { browserAfterEach, browserBeforeEach, browserDismissedDialogs, getUrl } from './browserSpecUtils'
+import { browserAfterEach, browserBeforeEach, getUrl } from './browserSpecUtils'
 // import mapStackTrace from 'sourcemapped-stacktrace-node')
 
 // Defined via jest-puppeteer environment
@@ -23,8 +23,53 @@ async function getAttrs() {
     })
 }
 
-async function pressKeys(keys: string[]) {
-    for (const key of keys) {
+const dialogMessages: string[] = []
+
+async function closeDialog() {
+    const dialogMessage = await page.evaluate(() => {
+        function findEl(sel: string) {
+            const ret = window.document.querySelector(sel)
+            if (!ret) { throw new Error(`BUG: Could not find selector "${sel}". Maybe it was renamed?`) }
+            return ret as HTMLElement
+        }
+
+        const dialog = findEl('#messageDialog')
+        const dialogCloseButton = findEl('#messageDialogClose')
+        const dialogText = findEl('#messageDialogText')
+
+        if (dialog.hasAttribute('open')) {
+            dialogCloseButton.click()
+            const oldCount = parseInt(dialog.getAttribute('data-dismissed-count') || '0', 10)
+            dialog.setAttribute('data-dismissed-count', `${oldCount + 1}`)
+            return dialogText.textContent
+        } else {
+            throw new Error(`BUG: Dialog was not open`)
+        }
+    }) as string
+
+    dialogMessages.push(dialogMessage)
+
+    // Verify the dialog was closed before continuing
+    await sleep(100)
+    await page.evaluate(() => {
+        const dialog = window.document.querySelector('#messageDialog')
+        const dialogCloseButton = window.document.querySelector('#messageDialogClose')
+        if (dialog && dialogCloseButton && !dialog.hasAttribute('open')) {
+            return
+        } else {
+            throw new Error(`BUG: Dialog does not exist or is still open`)
+        }
+    })
+}
+
+async function waitForDialogAndClose() {
+    await page.waitForSelector(`#messageDialog[open]`)
+    await closeDialog()
+}
+
+async function pressKeys(keys: string[], isLastPressADialog: boolean) {
+    for (let index = 0; index < keys.length; index++) {
+        const key = keys[index]
         if (key === ',') { continue }
         await page.waitFor(`.ps-table[data-ps-accepting-input='true']`)
         if (key === '.') {
@@ -38,8 +83,12 @@ async function pressKeys(keys: string[]) {
         await sleep(100) // because alerts might show up and they take some time to pop open?
         await page.keyboard.up(`Key${key}`)
         await sleep(100)
-        // wait until the keypress was processed
-        await page.waitFor(`.ps-table:not([data-ps-last-input-processed='${count}'])`)
+        // wait until the keypress was processed (might need to dismiss a dialog)
+        if (isLastPressADialog && index === keys.length - 1) {
+            await waitForDialogAndClose()
+        } else {
+            await page.waitFor(`.ps-table:not([data-ps-last-input-processed='${count}'])`)
+        }
     }
 }
 
@@ -75,7 +124,7 @@ async function playLevel() {
         }
     }, { source, startLevel })
 
-    await pressKeys('SAAASASDDDWDDDDWDDSAAASASAW'.split(''))
+    await pressKeys('SAAASASDDDWDDDDWDDSAAASASAW'.split(''), false)
 }
 
 describe('Browser', () => {
@@ -98,41 +147,36 @@ describe('Browser', () => {
     })
 
     it('plays a couple levels using the demo page', async() => {
-        const waitForDialogAfter = async(fn: () => Promise<any>) => {
-            // page.once('dialog', dialogHandler)
-            const oldCount = browserDismissedDialogs().length
-            await fn()
-            // Keep checking for the dialog to be dismissed
-            if (browserDismissedDialogs().length > oldCount) {
-                return
-            }
-            await sleep(100) // wait a little bit
-            if (browserDismissedDialogs().length > oldCount) {
-                return
-            }
-            await sleep(1000) // wait for the dialog to open and be dismissed
-            if (browserDismissedDialogs().length > oldCount) {
-                return
-            }
-            await sleep(10000) // wait a long time
-            expect(browserDismissedDialogs().length).toBeGreaterThan(oldCount)
+        const jsDismissedDialogs = async() => {
+            const ret = await page.evaluate(() => {
+                const dialog = window.document.querySelector('#messageDialog')
+                if (dialog) {
+                    return parseInt(dialog.getAttribute('data-dismissed-count') || '0', 10)
+                } else {
+                    return -1
+                }
+            })
+            return ret as number
         }
 
         // The game shows a dialog immediately (uggh)
-        await waitForDialogAfter(async() => {
-            await page.goto(getUrl(`index.xhtml`))
-            await page.waitForSelector(`#loadingIndicator.hidden`)
-        })
+        await page.goto(getUrl(`index.xhtml`))
+        await page.waitForSelector(`#loadingIndicator.hidden`)
+        await waitForDialogAndClose()
 
         // play a level and then wait for the dialog to open
         await page.waitForSelector(`.ps-table[data-ps-current-level="${1}"]`)
-        await waitForDialogAfter(async() => pressKeys('.AWAW'.split('')))
+        await pressKeys('.AWAW'.split(''), true)
 
         await page.waitForSelector(`.ps-table[data-ps-current-level="${3}"]`)
-        await waitForDialogAfter(async() => pressKeys('.WASDW'.split('')))
+        await pressKeys('.WASDW'.split(''), true)
 
         await page.waitForSelector(`.ps-table[data-ps-current-level="${5}"]`)
 
-        expect(browserDismissedDialogs().length).toBe(5)
+        const dismissedCount = await jsDismissedDialogs()
+        // if (dismissedCount !== 3) {
+        //     throw new Error(`Dialog count mismatch. Expected ${3} but got these: ${JSON.stringify(dialogMessages)}`)
+        // }
+        expect(dismissedCount).toBe(3)
     })
 })

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -2,11 +2,11 @@ import 'babel-polyfill' // tslint:disable-line:no-implicit-dependencies
 import * as dialogPolyfill from 'dialog-polyfill' // tslint:disable-line:no-implicit-dependencies
 import TimeAgo from 'javascript-time-ago' // tslint:disable-line:no-implicit-dependencies
 import TimeAgoEn from 'javascript-time-ago/locale/en' // tslint:disable-line
+import { BUTTON_TYPE } from './browser/controller/controller'
 import WebworkerTableEngine from './browser/WebworkerTableEngine'
 import { IGameTile } from './models/tile'
 import { Level } from './parser/astTypes'
 import { GameEngineHandlerOptional, Optional, pollingPromise } from './util'
-import { BUTTON_TYPE } from './browser/controller/controller';
 
 declare const ga: (a1: string, a2: string, a3: string, a4: string, a5?: string, a6?: number) => void
 

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -6,6 +6,7 @@ import WebworkerTableEngine from './browser/WebworkerTableEngine'
 import { IGameTile } from './models/tile'
 import { Level } from './parser/astTypes'
 import { GameEngineHandlerOptional, Optional, pollingPromise } from './util'
+import { BUTTON_TYPE } from './browser/controller/controller';
 
 declare const ga: (a1: string, a2: string, a3: string, a4: string, a5?: string, a6?: number) => void
 
@@ -209,6 +210,11 @@ window.addEventListener('load', () => {
                     gamepadDisabled.classList.add('hidden')
                     gamepadRecognized.classList.remove('hidden')
                     gamepadNotRecognized.classList.add('hidden')
+
+                    // Dismiss dialogs via the gamepad
+                    if (messageDialog.open && tableEngine.inputWatcher.gamepad.isButtonPressed(BUTTON_TYPE.CLUSTER_BOTTOM)) {
+                        messageDialogClose.click()
+                    }
                 } else if (tableEngine.inputWatcher.gamepad.isSomethingConnected()) {
                     // Send GA when someone adds a gamepad
                     if (gamepadNotRecognized.classList.contains('hidden')) {

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -1,11 +1,11 @@
 import 'babel-polyfill' // tslint:disable-line:no-implicit-dependencies
+import * as dialogPolyfill from 'dialog-polyfill' // tslint:disable-line:no-implicit-dependencies
 import TimeAgo from 'javascript-time-ago' // tslint:disable-line:no-implicit-dependencies
 import TimeAgoEn from 'javascript-time-ago/locale/en' // tslint:disable-line
-import * as dialogPolyfill from 'dialog-polyfill'
 import WebworkerTableEngine from './browser/WebworkerTableEngine'
 import { IGameTile } from './models/tile'
 import { Level } from './parser/astTypes'
-import { GameEngineHandlerOptional, pollingPromise, Optional } from './util'
+import { GameEngineHandlerOptional, Optional, pollingPromise } from './util'
 
 declare const ga: (a1: string, a2: string, a3: string, a4: string, a5?: string, a6?: number) => void
 
@@ -29,14 +29,14 @@ interface StorageGameInfo {
 
 interface Storage { [gameId: string]: StorageGameInfo }
 
-interface Dialog extends Element {
+interface Dialog extends HTMLElement {
     open: Optional<boolean>
     show(): void
     showModal(): void
     close(returnValue?: string): void
 }
 
-function getElement<T extends Element>(selector: string) {
+function getElement<T extends HTMLElement>(selector: string) {
     const el: Optional<T> = document.querySelector(selector)
     if (!el) {
         throw new Error(`BUG: Could not find "${selector}" in the page`)
@@ -84,7 +84,8 @@ window.addEventListener('load', () => {
             })
             messageDialogText.textContent = msg
             messageDialog.showModal()
-            ;(messageDialogClose as any).focus()
+            messageDialogClose.focus()
+
             await pollingPromise<void>(10, () => {
                 // Wait until the dialog has closed (and no keys are pressed down)
                 return !messageDialog.open
@@ -101,7 +102,7 @@ window.addEventListener('load', () => {
             //     ]
             // }
             // return new Promise((resolve) => {
-            //     // Notification is not available on iOS 
+            //     // Notification is not available on iOS
             //     if (typeof Notification !== 'undefined') { // tslint:disable-line:strict-type-predicates
             //         Notification.requestPermission(async(result) => { // tslint:disable-line:no-floating-promises
             //             // Safari does not support registration.showNotification() so we fall back to new Notification()

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -13,6 +13,11 @@ type PromptEvent = Event & {
     userChoice: Promise<{outcome: 'accepted' | 'rejected' | 'default'}>
 }
 
+// type NotificationEvent = Event & {
+//     action: Optional<string>
+//     notification: Notification
+// }
+
 interface StorageGameInfo {
     currentLevelNum: number
     completedLevelAt: number
@@ -56,51 +61,52 @@ window.addEventListener('load', () => {
     // Save when the user completes a level
     const handler: GameEngineHandlerOptional = {
         onMessage(msg) {
-
-            // Show a phone notification rather than an alert (if notifications are granted)
-            // Just to show that notifications can be done and what they would look like
-            const notificationOptions = {
-                body: `${msg} (Just showing that notifications work. You can disable them)`,
-                icon: './pwa-icon.png',
-                badge: './pwa-icon.png',
-                vibrate: [200, 100, 200],
-                actions: [
-                    { action: 'action-ok', title: 'ok' }
-                ]
-            }
-            return new Promise((resolve) => {
-                // Notification is not available on iOS 
-                if (typeof Notification !== 'undefined') { // tslint:disable-line:strict-type-predicates
-                    Notification.requestPermission(async(result) => { // tslint:disable-line:no-floating-promises
-                        // Safari does not support registration.showNotification() so we fall back to new Notification()
-                        const fallback = () => {
-                            new Notification('Annoying Test Message', notificationOptions) // tslint:disable-line:no-unused-expression
-                            resolve()
-                        }
-                        if (result === 'granted') {
-                            if (navigator.serviceWorker) {
-                                // Mobile notification (Android Chrome)
-                                const registration = await navigator.serviceWorker.ready
-                                if (registration.showNotification) {
-                                    await registration.showNotification('Annoying Test Message', notificationOptions)
-                                    resolve()
-                                } else {
-                                    fallback()
-                                }
-                            } else {
-                                // Desktop notification Fallback (Firefox)
-                                fallback()
-                            }
-                        } else {
-                            alert(msg)
-                            resolve()
-                        }
-                    })
-                } else {
-                    alert(msg)
-                    resolve()
-                }
-            })
+            alert(msg)
+            return Promise.resolve()
+            // // Show a phone notification rather than an alert (if notifications are granted)
+            // // Just to show that notifications can be done and what they would look like
+            // const notificationOptions = {
+            //     body: `${msg} (Just showing that notifications work. You can disable them)`,
+            //     icon: './pwa-icon.png',
+            //     badge: './pwa-icon.png',
+            //     vibrate: [200, 100, 200],
+            //     actions: [
+            //         { action: 'action-ok', title: 'ok' }
+            //     ]
+            // }
+            // return new Promise((resolve) => {
+            //     // Notification is not available on iOS 
+            //     if (typeof Notification !== 'undefined') { // tslint:disable-line:strict-type-predicates
+            //         Notification.requestPermission(async(result) => { // tslint:disable-line:no-floating-promises
+            //             // Safari does not support registration.showNotification() so we fall back to new Notification()
+            //             const fallback = () => {
+            //                 new Notification('Annoying Test Message', notificationOptions) // tslint:disable-line:no-unused-expression
+            //                 resolve()
+            //             }
+            //             if (result === 'granted') {
+            //                 if (navigator.serviceWorker) {
+            //                     // Mobile notification (Android Chrome)
+            //                     const registration = await navigator.serviceWorker.ready
+            //                     if (registration.showNotification) {
+            //                         await registration.showNotification('Annoying Test Message', notificationOptions)
+            //                         resolve()
+            //                     } else {
+            //                         fallback()
+            //                     }
+            //                 } else {
+            //                     // Desktop notification Fallback (Firefox)
+            //                     fallback()
+            //                 }
+            //             } else {
+            //                 alert(msg)
+            //                 resolve()
+            //             }
+            //         })
+            //     } else {
+            //         alert(msg)
+            //         resolve()
+            //     }
+            // })
         },
         onLevelChange(newLevelNum) {
             // Hide the Loading text because the level loaded
@@ -355,7 +361,7 @@ window.addEventListener('load', () => {
         deferredPrompt && deferredPrompt.prompt()
         // Wait for the user to respond to the prompt
         deferredPrompt && deferredPrompt.userChoice
-        .then((choiceResult) => {
+        .then(() => {
             deferredPrompt = null
         })
     })

--- a/typings/dialog-polyfill.d.ts
+++ b/typings/dialog-polyfill.d.ts
@@ -1,0 +1,7 @@
+declare module "dialog-polyfill" {
+    interface DialogPolyfill {
+        registerDialog(el: Element): void
+    }
+    var dialogPolyfill: DialogPolyfill
+    export = dialogPolyfill
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,6 +2566,11 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+dialog-polyfill@^0.4.10:
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/dialog-polyfill/-/dialog-polyfill-0.4.10.tgz#c4ea68a0deed4abb59a6a2a025c548b278cd532e"
+  integrity sha512-j5yGMkP8T00UFgyO+78OxiN5vC5dzRQF3BEio+LhNvDbyfxWBsi3sfPArDm54VloaJwy2hm3erEiDWqHRC8rzw==
+
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"


### PR DESCRIPTION
When the player is holding down a key and an alert pops up, they `keyUp` event does not fire so the browser thinks that is still pressed down. This fixes it **and** adds support for dismissing message using a gamepad/controller if one is detected.

This also includes a polyfill for browsers that do not support the native `<dialog>` markup (Firefox).

Thanks to @reedstrm for finding it!