### PR TITLE
support saving and loading checkpoints

### DIFF
--- a/src/browser/SyncTableEngine.ts
+++ b/src/browser/SyncTableEngine.ts
@@ -1,6 +1,6 @@
 import InputWatcher from '../browser/InputWatcher'
 import ResizeWatcher from '../browser/ResizeWatcher'
-import { GameEngine, CellSaveState } from '../engine'
+import { CellSaveState, GameEngine } from '../engine'
 import { LEVEL_TYPE } from '../parser/astTypes'
 import Parser from '../parser/parser'
 import TableUI from '../ui/table'

--- a/src/browser/SyncTableEngine.ts
+++ b/src/browser/SyncTableEngine.ts
@@ -1,6 +1,6 @@
 import InputWatcher from '../browser/InputWatcher'
 import ResizeWatcher from '../browser/ResizeWatcher'
-import { GameEngine } from '../engine'
+import { GameEngine, CellSaveState } from '../engine'
 import { LEVEL_TYPE } from '../parser/astTypes'
 import Parser from '../parser/parser'
 import TableUI from '../ui/table'
@@ -43,12 +43,12 @@ class SubTableEngine {
 
         this.tableUI = new TableUI(table, handler)
     }
-    public setGame(code: string, levelNum: number) {
+    public setGame(code: string, levelNum: number, checkpoint: Optional<CellSaveState>) {
         const { data } = Parser.parse(code)
         this.engine = new GameEngine(data, this.tableUI)
 
         this.tableUI.onGameChange(data)
-        this.engine.setLevel(levelNum)
+        this.engine.setLevel(levelNum, checkpoint)
 
         if (data.metadata.keyRepeatInterval) {
             this.inputWatcher.setKeyRepeatInterval(data.metadata.keyRepeatInterval)
@@ -108,8 +108,8 @@ export default class SyncTableEngine implements Engineish {
         this.table.addEventListener('blur', this.boundPause)
         this.table.addEventListener('focus', this.boundResume)
     }
-    public setGame(source: string, level: number = 0) {
-        this.subEngine.setGame(source, level)
+    public setGame(source: string, level: number = 0, checkpoint: Optional<CellSaveState>) {
+        this.subEngine.setGame(source, level, checkpoint)
 
         const engine = this.subEngine.getEngine()
         if (engine.getCurrentLevel().type === LEVEL_TYPE.MAP) {

--- a/src/browser/WebworkerTableEngine.ts
+++ b/src/browser/WebworkerTableEngine.ts
@@ -1,3 +1,4 @@
+import { CellSaveState } from '../engine'
 import { GameData } from '../models/game'
 import { A11Y_MESSAGE, A11Y_MESSAGE_TYPE } from '../models/rule'
 import { GameSprite } from '../models/tile'
@@ -17,7 +18,6 @@ import { Cellish,
     WorkerResponse } from '../util'
 import InputWatcher from './InputWatcher'
 import ResizeWatcher from './ResizeWatcher'
-import { CellSaveState } from '../engine';
 
 class ProxyCellish implements Cellish {
     public readonly rowIndex: number
@@ -101,13 +101,6 @@ export default class WebworkerTableEngine implements Engineish {
         clearInterval(this.inputInterval)
     }
 
-    private pollInputWatcher() {
-        const button = this.inputWatcher.pollControls()
-        if (button) {
-            this.press(button)
-        }
-    }
-
     public press(button: INPUT_BUTTON) {
         this.worker.postMessage({ type: MESSAGE_TYPE.PRESS, button })
     }
@@ -122,6 +115,13 @@ export default class WebworkerTableEngine implements Engineish {
         this.worker.postMessage({ type: MESSAGE_TYPE.RESUME })
         if (!this.inputInterval) {
             this.inputInterval = window.setInterval(this.pollInputWatcher, 10)
+        }
+    }
+
+    private pollInputWatcher() {
+        const button = this.inputWatcher.pollControls()
+        if (button) {
+            this.press(button)
         }
     }
     private async messageListener({ data }: {data: WorkerResponse}) {

--- a/src/browser/WebworkerTableEngine.ts
+++ b/src/browser/WebworkerTableEngine.ts
@@ -14,9 +14,10 @@ import { Cellish,
     pollingPromise,
     PuzzlescriptWorker,
     RULE_DIRECTION,
-    WorkerResponse} from '../util'
+    WorkerResponse } from '../util'
 import InputWatcher from './InputWatcher'
 import ResizeWatcher from './ResizeWatcher'
+import { CellSaveState } from '../engine';
 
 class ProxyCellish implements Cellish {
     public readonly rowIndex: number
@@ -90,8 +91,8 @@ export default class WebworkerTableEngine implements Engineish {
 
         this.inputInterval = window.setInterval(this.pollInputWatcher, 10)
     }
-    public setGame(code: string, level: number) {
-        this.worker.postMessage({ type: MESSAGE_TYPE.ON_GAME_CHANGE, code, level })
+    public setGame(code: string, level: number, checkpoint: Optional<CellSaveState>) {
+        this.worker.postMessage({ type: MESSAGE_TYPE.ON_GAME_CHANGE, code, level, checkpoint })
     }
 
     public dispose() {
@@ -150,7 +151,7 @@ export default class WebworkerTableEngine implements Engineish {
                 this.ui.onPress(data.direction)
                 break
             case MESSAGE_TYPE.ON_TICK:
-                this.ui.onTick(new Set(data.changedCells.map((x) => this.convertToCellish(x))), data.hasAgain, this.convertToA11yMessages(data.a11yMessages))
+                this.ui.onTick(new Set(data.changedCells.map((x) => this.convertToCellish(x))), data.checkpoint, data.hasAgain, this.convertToA11yMessages(data.a11yMessages))
                 break
             case MESSAGE_TYPE.ON_SOUND:
                 await this.ui.onSound({ soundCode: data.soundCode })

--- a/src/cli/playGame.ts
+++ b/src/cli/playGame.ts
@@ -345,7 +345,8 @@ async function playGame(data: GameData, currentLevelNum: number, recordings: ISa
         }
     })
     TerminalUI.clearScreen()
-    engine.setLevel(data.levels.indexOf(level))
+    // TODO: Support saving and loading checkpoints in the CLI
+    engine.setLevel(data.levels.indexOf(level), null/*no checkpoint*/)
 
     function restartLevel() {
         engine.press(INPUT_BUTTON.RESTART)

--- a/src/cli/runGames.ts
+++ b/src/cli/runGames.ts
@@ -90,7 +90,7 @@ async function run() {
             startTime = Date.now()
             const engine = new GameEngine(data, TerminalUI)
             const levelNum = data.levels.indexOf(currentLevel)
-            engine.setLevel(levelNum)
+            engine.setLevel(levelNum, null/*no checkpoint*/)
             logger.debug(() => `\n\nStart playing "${data.title}". Level ${levelNum}`)
 
             logger.info(() => `Loading Cells into the level took ${Date.now() - startTime}ms`)

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -609,6 +609,11 @@ export class LevelEngine extends EventEmitter2 {
         return { movedCells, a11yMessages }
     }
 
+    // Used for UNDO and RESTART
+    public createSnapshot() {
+        return this.getCurrentLevel().getCells().map((row) => row.map((cell) => cell.toSnapshot()))
+    }
+
     private pressDir(direction: INPUT_BUTTON) {
         // Should disable keypresses if `AGAIN` is running.
         // It is commented because the didSpritesChange logic is not correct.
@@ -820,11 +825,6 @@ export class LevelEngine extends EventEmitter2 {
         })
         return conditionsSatisfied
     }
-
-    // Used for UNDO and RESTART
-    public createSnapshot() {
-        return this.getCurrentLevel().getCells().map((row) => row.map((cell) => cell.toSnapshot()))
-    }
     private takeSnapshot(snapshot: Snapshot) {
         this.undoStack.push(snapshot)
     }
@@ -962,7 +962,7 @@ export class GameEngine {
             this.handler.onPress(previousPending)
         }
 
-        let checkpoint = hasCheckpoint ? this.saveSnapshotToJSON() : null
+        const checkpoint = hasCheckpoint ? this.saveSnapshotToJSON() : null
 
         if (hasRestart) {
             this.handler.onTick(changedCells, checkpoint, hasAgain, a11yMessages)

--- a/src/index-webworker.ts
+++ b/src/index-webworker.ts
@@ -1,5 +1,5 @@
 import 'babel-polyfill' // tslint:disable-line:no-implicit-dependencies
-import { Cell, GameEngine, CellSaveState } from './engine'
+import { Cell, CellSaveState, GameEngine } from './engine'
 import { GameData } from './models/game'
 import { A11Y_MESSAGE, A11Y_MESSAGE_TYPE } from './models/rule'
 import { GameSprite } from './models/tile'

--- a/src/index-webworker.ts
+++ b/src/index-webworker.ts
@@ -1,5 +1,5 @@
 import 'babel-polyfill' // tslint:disable-line:no-implicit-dependencies
-import { Cell, GameEngine } from './engine'
+import { Cell, GameEngine, CellSaveState } from './engine'
 import { GameData } from './models/game'
 import { A11Y_MESSAGE, A11Y_MESSAGE_TYPE } from './models/rule'
 import { GameSprite } from './models/tile'
@@ -19,7 +19,7 @@ let lastTick = 0
 onmessage = (event: TypedMessageEvent<WorkerMessage>) => {
     const msg = event.data
     switch (msg.type) {
-        case MESSAGE_TYPE.ON_GAME_CHANGE: loadGame(msg.code, msg.level); break
+        case MESSAGE_TYPE.ON_GAME_CHANGE: loadGame(msg.code, msg.level, msg.checkpoint); break
         case MESSAGE_TYPE.PAUSE: postMessage({ type: msg.type, payload: pauseGame() }); break
         case MESSAGE_TYPE.RESUME: postMessage({ type: msg.type, payload: resumeGame() }); break
         case MESSAGE_TYPE.PRESS: postMessage({ type: msg.type, payload: press(msg.button) }); break
@@ -99,8 +99,8 @@ class Handler implements GameEngineHandler {
     public async onSound(sound: Soundish) {
         postMessage({ type: MESSAGE_TYPE.ON_SOUND, soundCode: sound.soundCode })
     }
-    public onTick(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cell, GameSprite>>) {
-        postMessage({ type: MESSAGE_TYPE.ON_TICK, changedCells: toCellsJson(changedCells), hasAgain, a11yMessages: a11yMessages.map(toA11yMessageJson) })
+    public onTick(changedCells: Set<Cellish>, checkpoint: Optional<CellSaveState>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cell, GameSprite>>) {
+        postMessage({ type: MESSAGE_TYPE.ON_TICK, changedCells: toCellsJson(changedCells), checkpoint, hasAgain, a11yMessages: a11yMessages.map(toA11yMessageJson) })
     }
     public onPause() {
         postMessage({ type: MESSAGE_TYPE.ON_PAUSE })
@@ -110,13 +110,13 @@ class Handler implements GameEngineHandler {
     }
 }
 
-const loadGame = (code: string, level: number) => {
+const loadGame = (code: string, level: number, checkpoint: Optional<CellSaveState>) => {
     pauseGame()
     previousMessage = '' // clear this dev-invariant-tester field since it is a new game
     const { data } = Parser.parse(code)
     postMessage({ type: MESSAGE_TYPE.ON_GAME_CHANGE, payload: (new Serializer(data)).toJson() })
     currentEngine = new GameEngine(data, new Handler())
-    currentEngine.setLevel(level)
+    currentEngine.setLevel(level, checkpoint)
     runPlayLoop() // tslint:disable-line:no-floating-promises
 }
 

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -4,10 +4,10 @@ import TimeAgo from 'javascript-time-ago' // tslint:disable-line:no-implicit-dep
 import TimeAgoEn from 'javascript-time-ago/locale/en' // tslint:disable-line
 import { BUTTON_TYPE } from './browser/controller/controller'
 import WebworkerTableEngine from './browser/WebworkerTableEngine'
+import { CellSaveState } from './engine'
 import { IGameTile } from './models/tile'
 import { Level } from './parser/astTypes'
 import { GameEngineHandlerOptional, Optional, pollingPromise } from './util'
-import { CellSaveState } from './engine';
 
 declare const ga: (a1: string, a2: string, a3: string, a4: string, a5?: string, a6?: number) => void
 
@@ -190,7 +190,7 @@ window.addEventListener('load', () => {
                     const checkpoint = loadCheckpoint(currentGameId)
                     if (checkpoint) {
                         // verify that the currentLevelNum is the same as the checkpoint level num
-                        const {levelNum: checkpointLevelNum, data: checkpointData} = checkpoint
+                        const { levelNum: checkpointLevelNum, data: checkpointData } = checkpoint
                         if (levelNum !== checkpointLevelNum) {
                             throw new Error(`BUG: Checkpoint level number (${checkpointLevelNum}) does not match current level number (${levelNum})`)
                         }

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -21,13 +21,17 @@ type PromptEvent = Event & {
 //     notification: Notification
 // }
 
+interface StorageCheckpoint {
+    levelNum: number,
+    data: CellSaveState
+}
+
 interface StorageGameInfo {
     currentLevelNum: number
     completedLevelAt: number
     lastPlayedAt: number
     levelMaps: boolean[]
     title: string
-    checkpoint: Optional<{levelNum: number, data: CellSaveState}>
 }
 
 interface Storage { [gameId: string]: StorageGameInfo }
@@ -57,6 +61,7 @@ window.addEventListener('load', () => {
 
     const WEBWORKER_URL = './puzzlescript-webworker.js'
     const GAME_STORAGE_ID = 'puzzlescriptGameProgress'
+    const GAME_STORAGE_CHECKPOINT_PREFIX = 'puzzlescriptGameCheckpoint'
     const table: HTMLTableElement = getElement('#theGame')
     const gameSelection: HTMLSelectElement = getElement('#gameSelection')
     const loadingIndicator = getElement('#loadingIndicator')
@@ -68,14 +73,89 @@ window.addEventListener('load', () => {
     TimeAgo.addLocale(TimeAgoEn)
     const timeAgo = new TimeAgo('en-US')
 
-    let currentGameId = '' // used for loading and saving game progress
-
     if (!gameSelection) { throw new Error(`BUG: Could not find game selection dropdown`) }
     if (!loadingIndicator) { throw new Error(`BUG: Could not find loading indicator`) }
 
     messageDialogClose.addEventListener('click', () => {
         messageDialog.close()
     })
+
+    // Functions for loading/saving game progress
+    const currentInfo = new class {
+        private gameId: string
+        private levelNum: number
+
+        constructor() {
+            this.gameId = 'INVALID_GAME'
+            this.levelNum = -1
+        }
+
+        public setGameId(gameId: string) {
+            this.gameId = gameId
+            this.levelNum = -1
+        }
+        public getGameId() {
+            if (this.gameId === 'INVALID_GAME') {
+                throw new Error(`BUG: Did not set game id`)
+            }
+            return this.gameId
+        }
+        public getLevelNum() {
+            if (this.levelNum < 0) {
+                throw new Error(`BUG: Did not set level num`)
+            }
+            return this.levelNum
+        }
+        public loadStorage() {
+            const storage = this.loadJson(GAME_STORAGE_ID, { _version: 1 })
+            return storage as Storage
+        }
+        public loadCurrentLevelNum() {
+            const gameId = this.getGameId()
+            const storage = this.loadStorage()
+            const gameData = storage[gameId]
+            return (gameData || null) && gameData.currentLevelNum
+        }
+        public loadCheckpoint(): Optional<StorageCheckpoint> {
+            const gameId = this.getGameId()
+            return this.loadJson(`${GAME_STORAGE_CHECKPOINT_PREFIX}.${gameId}`, null)
+        }
+        public saveCurrentLevelNum(levelNum: number) {
+            const gameId = this.getGameId()
+            const storage = this.loadStorage()
+            storage[gameId] = storage[gameId] || {}
+            storage[gameId].currentLevelNum = levelNum
+            storage[gameId].completedLevelAt = Date.now()
+            storage[gameId].lastPlayedAt = Date.now()
+            // storage[gameId].checkpoint = null
+            this.saveJson(GAME_STORAGE_ID, storage)
+            ga && ga('send', 'event', 'game', 'level', gameId, levelNum)
+
+            currentInfo.levelNum = levelNum
+        }
+        public saveGameInfo(levels: Array<Level<IGameTile>>, title: string) {
+            const gameId = this.getGameId()
+            const storage = this.loadStorage()
+            storage[gameId] = storage[gameId] || {}
+            storage[gameId].levelMaps = levels.map((l) => l.type === 'LEVEL_MAP')
+            storage[gameId].title = title
+            storage[gameId].lastPlayedAt = Date.now()
+            this.saveJson(GAME_STORAGE_ID, storage)
+        }
+        public saveCheckpoint(checkpoint: CellSaveState) {
+            const gameId = this.getGameId()
+            const storage = { _version: 1, levelNum: this.getLevelNum(), data: checkpoint }
+            this.saveJson(`${GAME_STORAGE_CHECKPOINT_PREFIX}.${gameId}`, storage)
+        }
+
+        private loadJson<T>(key: string, defaultValue: T) {
+            const str = window.localStorage.getItem(key)
+            return str ? JSON.parse(str) : defaultValue
+        }
+        private saveJson<T>(key: string, value: T) {
+            window.localStorage.setItem(key, JSON.stringify(value))
+        }
+    }()
 
     // Save when the user completes a level
     const handler: GameEngineHandlerOptional = {
@@ -143,17 +223,17 @@ window.addEventListener('load', () => {
             loadingIndicator.classList.add('hidden')
             gameSelection.removeAttribute('disabled')
 
-            saveCurrentLevelNum(currentGameId, newLevelNum)
+            currentInfo.saveCurrentLevelNum(newLevelNum)
             updateGameSelectionInfo()
         },
         onGameChange(gameData) {
-            saveGameInfo(currentGameId, gameData.levels, gameData.title)
+            currentInfo.saveGameInfo(gameData.levels, gameData.title)
         },
         onTick(_changedCells, checkpoint) {
             if (checkpoint) {
                 // Ideally, include the level number so we can verify the checkpoint applies to the level
                 // This might require creating an onCheckpoint(levelNum, checkpoint) event
-                saveCheckpoint(currentGameId, checkpoint)
+                currentInfo.saveCheckpoint(checkpoint)
             }
         }
     }
@@ -177,26 +257,26 @@ window.addEventListener('load', () => {
         loadingIndicator.classList.remove('hidden') // Show the "Loading..." text
         gameSelection.setAttribute('disabled', 'disabled')
 
-        currentGameId = gameSelection.value
-        if (!currentGameId) {
+        currentInfo.setGameId(gameSelection.value)
+        if (!currentInfo.getGameId()) {
             return
         }
-        fetch(`./games/${currentGameId}/script.txt`, { redirect: 'follow' })
+        fetch(`./games/${currentInfo.getGameId()}/script.txt`, { redirect: 'follow' })
         .then((resp) => {
             if (resp.ok) {
                 return resp.text().then((source) => {
                     // Load the game
-                    const levelNum = loadCurrentLevelNum(currentGameId)
-                    const checkpoint = loadCheckpoint(currentGameId)
+                    const levelNum = currentInfo.loadCurrentLevelNum()
+                    const checkpoint = currentInfo.loadCheckpoint()
                     if (checkpoint) {
                         // verify that the currentLevelNum is the same as the checkpoint level num
                         const { levelNum: checkpointLevelNum, data: checkpointData } = checkpoint
                         if (levelNum !== checkpointLevelNum) {
                             throw new Error(`BUG: Checkpoint level number (${checkpointLevelNum}) does not match current level number (${levelNum})`)
                         }
-                        tableEngine.setGame(source, loadCurrentLevelNum(currentGameId) || 0, checkpointData)
+                        tableEngine.setGame(source, currentInfo.loadCurrentLevelNum() || 0, checkpointData)
                     } else {
-                        tableEngine.setGame(source, loadCurrentLevelNum(currentGameId) || 0, null)
+                        tableEngine.setGame(source, currentInfo.loadCurrentLevelNum() || 0, null)
                     }
                 })
             } else {
@@ -255,54 +335,13 @@ window.addEventListener('load', () => {
 
     }
 
-    // Functions for loading/saving game progress
-    function loadStorage() {
-        const storageStr = window.localStorage.getItem(GAME_STORAGE_ID)
-        const storage = storageStr ? JSON.parse(storageStr) : { _version: 1 }
-        return storage as Storage
-    }
-    function loadCurrentLevelNum(gameId: string) {
-        const storage = loadStorage()
-        const gameData = storage[gameId]
-        return (gameData || null) && gameData.currentLevelNum
-    }
-    function loadCheckpoint(gameId: string) {
-        const storage = loadStorage()
-        const gameData = storage[gameId]
-        return (gameData || null) && gameData.checkpoint
-    }
-    function saveCurrentLevelNum(gameId: string, levelNum: number) {
-        const storage = loadStorage()
-        storage[gameId] = storage[gameId] || {}
-        storage[gameId].currentLevelNum = levelNum
-        storage[gameId].completedLevelAt = Date.now()
-        storage[gameId].lastPlayedAt = Date.now()
-        // storage[gameId].checkpoint = null
-        window.localStorage.setItem(GAME_STORAGE_ID, JSON.stringify(storage))
-        ga && ga('send', 'event', 'game', 'level', gameId, levelNum)
-    }
-    function saveGameInfo(gameId: string, levels: Array<Level<IGameTile>>, title: string) {
-        const storage = loadStorage()
-        storage[gameId] = storage[gameId] || {}
-        storage[gameId].levelMaps = levels.map((l) => l.type === 'LEVEL_MAP')
-        storage[gameId].title = title
-        storage[gameId].lastPlayedAt = Date.now()
-        window.localStorage.setItem(GAME_STORAGE_ID, JSON.stringify(storage))
-    }
-    function saveCheckpoint(gameId: string, checkpoint: CellSaveState) {
-        const storage = loadStorage()
-        storage[gameId] = storage[gameId] || {}
-        storage[gameId].checkpoint = { levelNum: storage[gameId].currentLevelNum, data: checkpoint }
-        window.localStorage.setItem(GAME_STORAGE_ID, JSON.stringify(storage))
-    }
-
     // store the original sort order so that we fall back to it.
     gameSelection.querySelectorAll('option').forEach((option, index) => {
         option.setAttribute('data-original-index', `${index}`)
     })
 
     function updateGameSelectionInfo() {
-        const storage = loadStorage()
+        const storage = currentInfo.loadStorage()
 
         // Update the last-updated time for all of the games and then sort them
         const gameOptions = getAllElements('option', gameSelection)

--- a/src/replaySolutions/helper.ts
+++ b/src/replaySolutions/helper.ts
@@ -90,7 +90,7 @@ export function createTests(moduloNumber: number, moduloTotal: number) {
 
                     numPlayed++
 
-                    engine.setLevel(index)
+                    engine.setLevel(index, null/*no checkpoint*/)
 
                     // UI.setGame(engine)
 

--- a/src/ui.spec.ts
+++ b/src/ui.spec.ts
@@ -11,7 +11,7 @@ const C_BLACK = { r: 0, g: 0, b: 0 }
 function parseAndReturnFirstSpritePixels(code: string) {
     const { data } = Parser.parse(code)
     const engine = new GameEngine(data, new EmptyGameEngineHandler())
-    engine.setLevel(0)
+    engine.setLevel(0, null/*no checkpoint*/)
     const cell = engine.getCurrentLevelCells()[0][0]
     // console.log(cell.getSprites())
     UI.onGameChange(engine.getGameData())

--- a/src/ui/table.ts
+++ b/src/ui/table.ts
@@ -1,3 +1,4 @@
+import { CellSaveState } from '../engine'
 import { IColor } from '../models/colors'
 import { GameData } from '../models/game'
 import { A11Y_MESSAGE, A11Y_MESSAGE_TYPE } from '../models/rule'
@@ -17,7 +18,6 @@ import {
     spritesThatInteractWithPlayer
 } from '../util'
 import BaseUI from './base'
-import { CellSaveState } from '../engine';
 
 interface ITableCell {
     td: HTMLTableCellElement,

--- a/src/ui/table.ts
+++ b/src/ui/table.ts
@@ -17,6 +17,7 @@ import {
     spritesThatInteractWithPlayer
 } from '../util'
 import BaseUI from './base'
+import { CellSaveState } from '../engine';
 
 interface ITableCell {
     td: HTMLTableCellElement,
@@ -182,13 +183,13 @@ class TableUI extends BaseUI implements GameEngineHandler {
         playSound(sound.soundCode) // tslint:disable-line:no-floating-promises
         await this.handler.onSound(sound)
     }
-    public onTick(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>) {
+    public onTick(changedCells: Set<Cellish>, checkpoint: Optional<CellSaveState>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>) {
         this.collectingTickCount++
         this.printMessageLog(a11yMessages, hasAgain)
         this.drawCells(changedCells, false)
         this.markAcceptingInput(!hasAgain)
         this.didPressCauseTick = false
-        this.handler.onTick(changedCells, hasAgain, a11yMessages)
+        this.handler.onTick(changedCells, checkpoint, hasAgain, a11yMessages)
     }
 
     public willAllLevelsFitOnScreen(gameData: GameData) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import { GameData } from '.'
-import { Cell } from './engine'
+import { Cell, CellSaveState } from './engine'
 import { GameMetadata } from './models/metadata'
 import { A11Y_MESSAGE } from './models/rule'
 import { GameSprite } from './models/tile'
@@ -304,6 +304,7 @@ export type WorkerMessage = {
     type: MESSAGE_TYPE.ON_GAME_CHANGE
     code: string
     level: number
+    checkpoint: Optional<CellSaveState>
 } | {
     type: MESSAGE_TYPE.PRESS
     button: INPUT_BUTTON
@@ -358,6 +359,7 @@ export type WorkerResponse = {
 } | {
     type: MESSAGE_TYPE.ON_TICK
     changedCells: CellishJson[]
+    checkpoint: Optional<CellSaveState>
     hasAgain: boolean
     a11yMessages: Array<A11Y_MESSAGE<CellishJson, string>>
 }
@@ -392,7 +394,7 @@ export interface GameEngineHandler {
     onLevelChange(level: number, cells: Optional<Cellish[][]>, message: Optional<string>): void
     onWin(): void
     onSound(sound: Soundish): Promise<void>
-    onTick(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cell, GameSprite>>): void
+    onTick(changedCells: Set<Cellish>, checkpoint: Optional<CellSaveState>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cell, GameSprite>>): void
     onPause(): void
     onResume(): void
     // onGameChange(data: GameData): void
@@ -405,7 +407,7 @@ export interface GameEngineHandlerOptional {
     onLevelChange?(level: number, cells: Optional<Cellish[][]>, message: Optional<string>): void
     onWin?(): void
     onSound?(sound: Soundish): Promise<void>
-    onTick?(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>): void
+    onTick?(changedCells: Set<Cellish>, checkpoint: Optional<CellSaveState>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>): void
     onPause?(): void
     onResume?(): void
     // onGameChange?(data: GameData): void
@@ -422,8 +424,8 @@ export class EmptyGameEngineHandler implements GameEngineHandler {
     public onLevelChange(level: number, cells: Optional<Cellish[][]>, message: Optional<string>) { for (const h of this.subHandlers) { h.onLevelChange && h.onLevelChange(level, cells, message) } }
     public onWin() { for (const h of this.subHandlers) { h.onWin && h.onWin() } }
     public async onSound(sound: Soundish) { for (const h of this.subHandlers) { h.onSound && h.onSound(sound) } }
-    public onTick(changedCells: Set<Cellish>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>) {
-        for (const h of this.subHandlers) { h.onTick && h.onTick(changedCells, hasAgain, a11yMessages) }
+    public onTick(changedCells: Set<Cellish>, checkpoint: Optional<CellSaveState>, hasAgain: boolean, a11yMessages: Array<A11Y_MESSAGE<Cellish, GameSprite>>) {
+        for (const h of this.subHandlers) { h.onTick && h.onTick(changedCells, checkpoint, hasAgain, a11yMessages) }
     }
     public onPause() { for (const h of this.subHandlers) { h.onPause && h.onPause() } }
     public onResume() { for (const h of this.subHandlers) { h.onResume && h.onResume() } }
@@ -431,7 +433,7 @@ export class EmptyGameEngineHandler implements GameEngineHandler {
 }
 
 export interface Engineish {
-    setGame(code: string, level: number): void
+    setGame(code: string, level: number, checkpoint: Optional<CellSaveState>): void
     dispose(): void
     pause?(): void
     resume?(): void


### PR DESCRIPTION
Some games use checkpoints rather than levels to save the players' progress. These are usually large games that require the player to move between multiple screens in order to complete puzzles. This PR adds support for saving and loading those checkpoints 🎉 

Refs #104 and #107

# TODO

- [x] store each checkpoint in a separate key in `localStorage` (& clear them when the level changes)

### Screencap showing that progress is saved by reloading the page a couple of times:

![kapture 2019-02-24 at 13 30 32](https://user-images.githubusercontent.com/253202/53304217-68422480-3838-11e9-95c4-eed5ba454bf3.gif)


/cc @lwtchu . This PR will likely also fix the other 0% and 100% complete bugs 😄 