### PR TITLE
use zen screen instead of full screen

### DIFF
--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -170,10 +170,11 @@
         :-webkit-full-screen #theGame { margin: auto; }
         :-moz-full-screen #theGame { margin: auto; }
         :-ms-fullscreen #theGame { margin: auto; }
+        body.is-zen-screen #fullscreenRoot { margin: auto; }
 
         #enterFullscreen,
         #exitFullscreen {
-            position: absolute;
+            position: fixed;
             bottom: 0;
             right: 0;
 
@@ -198,7 +199,11 @@
         :-webkit-full-screen #exitFullscreen { display: block; }
         :-moz-full-screen #exitFullscreen { display: block; }
         :-ms-fullscreen #exitFullscreen { display: block; }
+        body.is-zen-screen #exitFullscreen { display: block; }
 
+        body.is-zen-screen #enterFullscreen,
+        body.is-zen-screen #infoContainer,
+        body.is-zen-screen #instructionsContainer { display: none; }
     </style>
 
     <meta charset="utf-8"/>

--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -177,16 +177,17 @@
             position: fixed;
             bottom: 0;
             right: 0;
+        }
 
+        #messageDialogClose,
+        #enterFullscreen,
+        #exitFullscreen {
             cursor: pointer;
             padding: 0.5rem;
             margin: 0.5rem;
             border: 1px solid #666;
             border-radius: 6px;
-        }
 
-        #enterFullscreen,
-        #exitFullscreen { 
             color: white;
             background-color: rgba(90, 90, 238);
             box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
@@ -222,10 +223,12 @@
     <div id="infoContainer">
         <div class="panel-header">
             <h1 id="headingSection" class="panel-title">Accessible <a href="https://github.com/philschatz/puzzlescript">Puzzle Games</a></h1>
+            <button id="enterFullscreen2" aria-label="Hide Game Selection Menu" class="close">
+                <span aria-hidden="true">×</span>
+            </button>
         </div>
 
         <p id="disableCssSection"><input id="disableCss" type="checkbox"/> <label for="disableCss"><strong>Check</strong> to see what a non-sighted user would experience (disables CSS)</label></p>
-    
         <p id="gameSelectionSection">
             <button id="btnAdd" class="hidden">Add to Homescreen?</button>
             <label for="gameSelection">Currently playing:</label>
@@ -301,7 +304,7 @@
     <div id="instructionsContainer">
         <div class="panel-header">
             <h2 class="panel-title">Instructions</h2>
-            <button id="closeInstructions" aria-label="Close" class="close">
+            <button id="enterFullscreen3" aria-label="Hide Game Instructions" class="close">
                 <span aria-hidden="true">×</span>
             </button>
         </div>

--- a/src/browser/ResizeWatcher.ts
+++ b/src/browser/ResizeWatcher.ts
@@ -26,15 +26,15 @@ export default class ResizeWatcher {
         // Resize the table so that it fits.
         const levelRatio = this.columns / this.rows
         // Figure out if the width or the height is the limiting factor
-        const availableWidth = window.outerWidth - this.table.offsetLeft
-        const availableHeight = window.outerHeight - this.table.offsetTop
+        const availableWidth = Math.min(window.outerWidth, window.innerWidth) - this.table.offsetLeft
+        const availableHeight = Math.min(window.outerHeight, window.innerHeight) - this.table.offsetTop
         let newWidth = 0
         if (availableWidth / levelRatio < availableHeight) {
             // Width is the limiting factor
-            newWidth = availableWidth
+            newWidth = Math.floor(availableWidth / this.columns / 5) * this.columns * 5
         } else {
             // Height is the limiting factor
-            newWidth = availableHeight * levelRatio
+            newWidth = Math.floor(availableHeight * levelRatio / this.rows / 5) * this.rows * 5
         }
         this.handler(Math.floor(newWidth))
     }

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -71,11 +71,11 @@ window.addEventListener('load', () => {
     const loadingIndicator = getElement('#loadingIndicator')
     const authorSection = getElement('#authorSection')
     const authorInfo = getElement('#authorInfo')
-    const instructionsContainer = getElement('#instructionsContainer')
-    const closeInstructions = getElement('#closeInstructions')
-    const fullscreenRoot = getElement('#fullscreenRoot')
+    // const fullscreenRoot = getElement('#fullscreenRoot')
     // Like full screen but keep the browser bar. Also, alerts break fullscreen but not zenscreen
     const enterFullscreen = getElement('#enterFullscreen')
+    const enterFullscreen2 = getElement('#enterFullscreen2')
+    const enterFullscreen3 = getElement('#enterFullscreen3')
     const exitFullscreen = getElement('#exitFullscreen')
     const messageDialog = getElement<Dialog>('#messageDialog')
     const messageDialogText = getElement('#messageDialogText')
@@ -184,12 +184,6 @@ window.addEventListener('load', () => {
         messageDialog.close()
     })
 
-    closeInstructions.addEventListener('click', () => {
-        instructionsContainer.classList.add('hidden')
-        // resize the game
-        tableEngine.resize()
-    })
-
     // // Hide the fullscreen button if it is not available in the browser
     // {
     //     const doc = document as any
@@ -198,7 +192,7 @@ window.addEventListener('load', () => {
     //         enterFullscreen.style.display = 'none'
     //     }
     // }
-    enterFullscreen.addEventListener('click', () => {
+    const enterFullscreenHandler = () => {
         document.body.classList.add('is-zen-screen')
         // const el = fullscreenRoot as any
         // if (el.requestFullscreen) {
@@ -212,7 +206,10 @@ window.addEventListener('load', () => {
         // }
         table.focus() // do not lose focus
         tableEngine.resize()
-    })
+    }
+    enterFullscreen.addEventListener('click', enterFullscreenHandler)
+    enterFullscreen2.addEventListener('click', enterFullscreenHandler)
+    enterFullscreen3.addEventListener('click', enterFullscreenHandler)
 
     exitFullscreen.addEventListener('click', () => {
         document.body.classList.remove('is-zen-screen')

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -74,6 +74,7 @@ window.addEventListener('load', () => {
     const instructionsContainer = getElement('#instructionsContainer')
     const closeInstructions = getElement('#closeInstructions')
     const fullscreenRoot = getElement('#fullscreenRoot')
+    // Like full screen but keep the browser bar. Also, alerts break fullscreen but not zenscreen
     const enterFullscreen = getElement('#enterFullscreen')
     const exitFullscreen = getElement('#exitFullscreen')
     const messageDialog = getElement<Dialog>('#messageDialog')
@@ -189,40 +190,42 @@ window.addEventListener('load', () => {
         tableEngine.resize()
     })
 
-    // Hide the fullscreen button if it is not available in the browser
-    {
-        const doc = document as any
-        const isFullscreenEnabled = document.fullscreenEnabled || doc.webkitFullscreenEnabled || doc.mozFullScreenEnabled || doc.msFullScreenEnabled
-        if (!isFullscreenEnabled) {
-            enterFullscreen.style.display = 'none'
-        }
-    }
+    // // Hide the fullscreen button if it is not available in the browser
+    // {
+    //     const doc = document as any
+    //     const isFullscreenEnabled = document.fullscreenEnabled || doc.webkitFullscreenEnabled || doc.mozFullScreenEnabled || doc.msFullScreenEnabled
+    //     if (!isFullscreenEnabled) {
+    //         enterFullscreen.style.display = 'none'
+    //     }
+    // }
     enterFullscreen.addEventListener('click', () => {
-        const el = fullscreenRoot as any
-        if (el.requestFullscreen) {
-            el.requestFullscreen()
-        } else if (el.webkitRequestFullScreen) {
-            el.webkitRequestFullScreen()
-        } else if (el.mozRequestFullScreen) {
-            el.mozRequestFullScreen()
-        } else if (el.msRequestFullscreen) {
-            el.msRequestFullscreen()
-        }
+        document.body.classList.add('is-zen-screen')
+        // const el = fullscreenRoot as any
+        // if (el.requestFullscreen) {
+        //     el.requestFullscreen()
+        // } else if (el.webkitRequestFullScreen) {
+        //     el.webkitRequestFullScreen()
+        // } else if (el.mozRequestFullScreen) {
+        //     el.mozRequestFullScreen()
+        // } else if (el.msRequestFullscreen) {
+        //     el.msRequestFullscreen()
+        // }
         table.focus() // do not lose focus
         tableEngine.resize()
     })
 
     exitFullscreen.addEventListener('click', () => {
-        const el = document as any
-        if (el.exitFullscreen) {
-            el.exitFullscreen()
-        } else if (el.webkitExitFullscreen) {
-            el.webkitExitFullscreen()
-        } else if (el.mozCancelFullScreen) {
-            el.mozCancelFullScreen()
-        } else if (el.msExitFullscreen) {
-            el.msExitFullscreen()
-        }
+        document.body.classList.remove('is-zen-screen')
+        // const el = document as any
+        // if (el.exitFullscreen) {
+        //     el.exitFullscreen()
+        // } else if (el.webkitExitFullscreen) {
+        //     el.webkitExitFullscreen()
+        // } else if (el.mozCancelFullScreen) {
+        //     el.mozCancelFullScreen()
+        // } else if (el.msExitFullscreen) {
+        //     el.msExitFullscreen()
+        // }
         table.focus() // do not lose focus
         tableEngine.resize()
     })

--- a/style.css
+++ b/style.css
@@ -10,6 +10,7 @@ table.ps-table:not(.ps-ui-disabled) {
 }
 table.ps-table:not(.ps-ui-disabled) tr td.ps-cell {
     position: relative;
+    padding: 0; /* it is 1px by default in Chromium */
 }
 table.ps-table:not(.ps-ui-disabled) td.ps-cell::after {
     content: '';


### PR DESCRIPTION
full screen has problems with alerts causing the game to drop out and it is annoying on desktops to take over the whole screen. This change instead clears all of the other elements off the screen