### PR TITLE
feat: Simplify UI and instructions

### DIFF
--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -33,7 +33,10 @@
         
 
 
-        body { font-family: helvetica, arial, sans-serif; }
+        body {
+            font-size: 12px;
+            font-family: helvetica, arial, sans-serif; 
+        }
         .hidden { display: none; }
         .light { opacity: .5; }
         kbd {
@@ -49,6 +52,11 @@
             border-bottom-color: #959da5;
             border-radius: 3px;
             box-shadow: inset 0 -1px 0 #959da5;
+        }
+        hr {
+            border-style: solid;
+            border-top: 0;
+            border-bottom: 1px solid #ccc;
         }
 
         /* Decide whether to move the following (all) to the html-table.css file */
@@ -183,6 +191,21 @@
             background-color: rgba(90, 90, 238);
             box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
         }
+        #gameInstructionsButton {
+            float: right;
+            padding: 0.25rem;
+        }
+
+        .ui-features-list { 
+            list-style-type: none;
+            padding-inline-start: 0;
+        }
+
+        .ui-features-list li {
+            margin-bottom: 1rem;
+            border-left: 2px solid rgba(90, 90, 238);
+            padding-left: .5rem;
+        }
 
         /* =================================================
          * FullScreen controls and styles 
@@ -190,35 +213,32 @@
          */
 
         /* NOTE: Using a comma does not work in chrome, so they are enumerated */
-        :fullscreen #theGame { margin: auto; }
+        /* :fullscreen #theGame { margin: auto; }
         :-webkit-full-screen #theGame { margin: auto; }
         :-moz-full-screen #theGame { margin: auto; }
-        :-ms-fullscreen #theGame { margin: auto; }
+        :-ms-fullscreen #theGame { margin: auto; } */
         body.is-zen-screen #fullscreenRoot { margin: auto; }
 
-        #enterFullscreen,
-        #exitFullscreen {
+        #fullscreenButtons {
             position: fixed;
-            bottom: 0;
-            right: 0;
+            top: 0;
+            left: 0;
         }
 
+        body:not(.is-zen-screen) #fullscreenButtons { display: none; }
+
         #messageDialogClose,
-        #enterFullscreen,
         #exitFullscreen {
             margin: 0.5rem;
         }
 
-        #exitFullscreen { display: none; }
-
         /* NOTE: Using a comma does not work in chrome, so they are enumerated */
-        :fullscreen #exitFullscreen { display: block; }
+        /* :fullscreen #exitFullscreen { display: block; }
         :-webkit-full-screen #exitFullscreen { display: block; }
         :-moz-full-screen #exitFullscreen { display: block; }
         :-ms-fullscreen #exitFullscreen { display: block; }
-        body.is-zen-screen #exitFullscreen { display: block; }
+        body.is-zen-screen #exitFullscreen { display: block; } */
 
-        body.is-zen-screen #enterFullscreen,
         body.is-zen-screen #infoContainer,
         body.is-zen-screen #instructionsContainer { display: none; }
     </style>
@@ -238,15 +258,11 @@
 <body>
     <div id="infoContainer">
         <div class="panel-header">
-            <h1 id="headingSection" class="panel-title">Accessible <a href="https://github.com/philschatz/puzzlescript">Puzzle Games</a></h1>
-            <button id="enterFullscreen2" aria-label="Hide Game Selection Menu" class="close">
+            <h1 id="headingSection" class="panel-title">Accessible <a href="https://github.com/philschatz/puzzlescript" target="_window">Puzzle Games</a></h1>
+            <button id="enterFullscreen" aria-label="Hide Game Selection Menu" class="close">
                 <span aria-hidden="true">×</span>
             </button>
         </div>
-
-        <p id="disableCssSection"><input id="disableCss" type="checkbox"/> <label for="disableCss"><strong>Check</strong> to see what a non-sighted user would experience (disables CSS)</label></p>
-    
-        <p><button id="gameInstructionsButton" class="ui-button">Help</button></p>
 
         <p id="gameSelectionSection">
             <button id="btnAdd" class="hidden">Add to Homescreen?</button>
@@ -295,12 +311,21 @@
     
         <p id="authorSection" class="hidden"><small>By <a id="authorInfo" target="_window"></a></small></p>
 
-        <p id="gamepadSection">
-            <img id="gamepadIcon" alt="gamepad icon" width="42" height="42" src="./pwa-icon.svg"/>
-            <span id="gamepadDisabled" class="hidden"><strong>Tip:</strong> Connect a gamepad controller (XBOX/PS3/PS4/etc) to use it to play.</span>
-            <span id="gamepadRecognized" class="hidden">Gamepad is detected. You can play using it now. Just make sure the game is focused.</span>
-            <span id="gamepadNotRecognized" class="hidden">Gamepad is detected but not recognized. Please submit an Issue on the Repository and we will help get it added</span>
-        </p>
+        <hr/>
+        
+        <h3><button id="gameInstructionsButton" class="ui-button">Help</button> Features</h3>
+
+        <ul class="ui-features-list">
+            <li id="disableCssSection"><input id="disableCss" type="checkbox"/> <label for="disableCss"><strong>Check</strong> to see what a non-sighted user would experience (disables CSS)</label></li>
+            <li>Install as a mobile app by opening on a phone/tablet</li>
+            <li id="gamepadSection">
+                <img id="gamepadIcon" alt="gamepad icon" width="20" height="20" src="./pwa-icon.svg"/>
+                <span id="gamepadDisabled" class="hidden"><strong>Tip:</strong> Connect a gamepad controller (XBOX/PS3/PS4/etc) to use it to play.</span>
+                <span id="gamepadRecognized" class="hidden">Gamepad is detected. You can play using it now. Just make sure the game is focused.</span>
+                <span id="gamepadNotRecognized" class="hidden">Gamepad is detected but not recognized. Please submit an Issue on the Repository and we will help get it added</span>
+            </li>
+        </ul>
+
     
     </div>
     
@@ -317,14 +342,12 @@
                 <div role="log" aria-live="polite">The Game log</div>
             </caption>
         </table>
-        <button id="exitFullscreen" class="ui-button">
-            Exit Fullscreen
-        </button>
+        
+        <div id="fullscreenButtons">
+            <button id="exitFullscreen" class="ui-button">Show Menu</button>
+            <button id="gameInstructionsButton2" class="ui-button">Help</button>
+        </div>
     </div>
-
-    <button id="enterFullscreen" class="ui-button">
-        Fullscreen
-    </button>
 
 
     <dialog id="gameInstructionsDialog">

--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -21,17 +21,12 @@
         #gamepadSectionPWA { display: none; }
 
         /* Show instructions depending on whether the user has a keyboard, touch screen, or both */
+        /* https://stackoverflow.com/a/52854585 */
         #touchInstructionsSection { opacity: 0.25; }
-        #keyboardInstructionsSection { display: none; }
-
         @media (any-pointer: coarse) {
             #touchInstructionsSection { opacity: 1; }
-        }
-        @media (any-hover: hover) {
-            #keyboardInstructionsSection { display: block; }
-        }
-        
-
+            #keyboardInstructionsSection { display: none; }
+        }        
 
         body {
             font-size: 12px;

--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -21,11 +21,11 @@
         #gamepadSectionPWA { display: none; }
 
         /* Show instructions depending on whether the user has a keyboard, touch screen, or both */
-        #touchInstructionsSection,
+        #touchInstructionsSection { opacity: 0.25; }
         #keyboardInstructionsSection { display: none; }
 
         @media (any-pointer: coarse) {
-            #touchInstructionsSection { display: block; }
+            #touchInstructionsSection { opacity: 1; }
         }
         @media (any-hover: hover) {
             #keyboardInstructionsSection { display: block; }
@@ -173,6 +173,17 @@
             }
         }
 
+        button.ui-button {
+            cursor: pointer;
+            padding: 0.5rem;
+            border: 1px solid #666;
+            border-radius: 6px;
+
+            color: white;
+            background-color: rgba(90, 90, 238);
+            box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+        }
+
         /* =================================================
          * FullScreen controls and styles 
          * =================================================
@@ -195,15 +206,7 @@
         #messageDialogClose,
         #enterFullscreen,
         #exitFullscreen {
-            cursor: pointer;
-            padding: 0.5rem;
             margin: 0.5rem;
-            border: 1px solid #666;
-            border-radius: 6px;
-
-            color: white;
-            background-color: rgba(90, 90, 238);
-            box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
         }
 
         #exitFullscreen { display: none; }
@@ -243,7 +246,7 @@
 
         <p id="disableCssSection"><input id="disableCss" type="checkbox"/> <label for="disableCss"><strong>Check</strong> to see what a non-sighted user would experience (disables CSS)</label></p>
     
-        <p><button id="gameInstructionsButton">Help</button></p>
+        <p><button id="gameInstructionsButton" class="ui-button">Help</button></p>
 
         <p id="gameSelectionSection">
             <button id="btnAdd" class="hidden">Add to Homescreen?</button>
@@ -304,7 +307,7 @@
     <div id="fullscreenRoot">
         <dialog id="messageDialog">
             <p id="messageDialogText"></p>
-            <button id="messageDialogClose" title="Close this window">Close</button>
+            <button id="messageDialogClose" title="Close this window" class="ui-button">Close</button>
         </dialog>
             
         <table id="theGame" aria-labelledby="keyboardInstructionsSection">
@@ -314,12 +317,12 @@
                 <div role="log" aria-live="polite">The Game log</div>
             </caption>
         </table>
-        <button id="exitFullscreen">
+        <button id="exitFullscreen" class="ui-button">
             Exit Fullscreen
         </button>
     </div>
 
-    <button id="enterFullscreen">
+    <button id="enterFullscreen" class="ui-button">
         Fullscreen
     </button>
 
@@ -329,6 +332,16 @@
             <h2 class="panel-title">How to Play</h2>
         </div>
         
+        <div id="keyboardInstructionsSection">
+            <p>To play with a keyboard:</p>
+            <ul>
+                <li>Arrow keys or <kbd>W</kbd>, <kbd>S</kbd>, <kbd>A</kbd>, <kbd>D</kbd> to move</li>
+                <li><kbd>X</kbd> to perform an Action</li>
+                <li><kbd>Z</kbd> or <kbd>U</kbd> for Undo</li>
+                <li><kbd>R</kbd> to Restart the current level</li>
+            </ul>
+        </div>
+
         <div id="touchInstructionsSection">
             <p>To play with a touch screen:</p>
             <ul>
@@ -336,16 +349,6 @@
                 <li><strong>Tap</strong> to perform an Action</li>
                 <li><strong>Touch and Hold</strong> to Undo</li>
                 <li><strong>Touch and Hold for a few seconds</strong> to Restart the current level</li>
-            </ul>
-        </div>
-
-        <div id="keyboardInstructionsSection">
-            <p>To play with a keyboard:</p>
-            <ul>
-                <li>Arrow keys or <kbd>W</kbd>, <kbd>S</kbd>, <kbd>A</kbd>, <kbd>D</kbd></li>
-                <li><kbd>X</kbd> to perform an Action</li>
-                <li><kbd>Z</kbd> or <kbd>U</kbd> for Undo</li>
-                <li><kbd>R</kbd> to Restart the current level</li>
             </ul>
         </div>
         
@@ -359,7 +362,7 @@
             </p>
         </div>
     
-        <button id="gameInstructionsDialogClose" title="Close">Close</button>
+        <button id="gameInstructionsDialogClose" title="Close" class="ui-button">Close</button>
     </dialog>
 
     <script type="text/javascript">//<![CDATA[

--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -11,7 +11,7 @@
          */
         @media all and (display-mode: standalone) {
             /* #headingSection, Uncommenting this causes horizontal lines on Android */
-            #gameInstructionsSection,
+            #keyboardInstructionsSection,
             #disableCssSection,
             #instructionsContainer,
             #gamepadSection { display: none; }
@@ -19,6 +19,19 @@
         }
         /* Hide by default */
         #gamepadSectionPWA { display: none; }
+
+        /* Show instructions depending on whether the user has a keyboard, touch screen, or both */
+        #touchInstructionsSection,
+        #keyboardInstructionsSection { display: none; }
+
+        @media (any-pointer: coarse) {
+            #touchInstructionsSection { display: block; }
+        }
+        @media (any-hover: hover) {
+            #keyboardInstructionsSection { display: block; }
+        }
+        
+
 
         body { font-family: helvetica, arial, sans-serif; }
         .hidden { display: none; }
@@ -276,7 +289,7 @@
             <button id="messageDialogClose" title="Close this window">Close</button>
         </dialog>
             
-        <table id="theGame" aria-labelledby="gameInstructionsSection">
+        <table id="theGame" aria-labelledby="keyboardInstructionsSection">
             <caption>
                 Game info goes here. like the current level, the goal, etc.
                 <!-- See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions -->
@@ -301,11 +314,21 @@
             </button>
         </div>
         
-        <div id="gameInstructionsSection">
-            <p>To play:</p>
+        <div id="touchInstructionsSection">
+            <p>To play with a touch screen:</p>
+            <ul>
+                <li><strong>Swipe</strong> up, down, left, or right to move</li>
+                <li><strong>Tap</strong> to perform an Action</li>
+                <li><strong>Touch and Hold</strong> to Undo</li>
+                <li><strong>Touch and Hold for a few seconds</strong> to Restart the current level</li>
+            </ul>
+        </div>
+
+        <div id="keyboardInstructionsSection">
+            <p>To play with a keyboard:</p>
             <ul>
                 <li>Arrow keys or <kbd>W</kbd>, <kbd>S</kbd>, <kbd>A</kbd>, <kbd>D</kbd></li>
-                <li><kbd>X</kbd> for Action</li>
+                <li><kbd>X</kbd> to perform an Action</li>
                 <li><kbd>Z</kbd> or <kbd>U</kbd> for Undo</li>
                 <li><kbd>R</kbd> to Restart the current level</li>
             </ul>
@@ -313,7 +336,7 @@
     
         <p id="gamepadSection">
             <img id="gamepadIcon" alt="gamepad icon" width="42" height="42" src="./pwa-icon.svg"/>
-            <span id="gamepadDisabled" class="hidden"><strong>Tip:</strong> Connect a gamepad controller (XBOX/PS3/PS4/etc) to use it to play games. You might need to press some buttons so it is detected. Occasionally, a driver needs to be installed.</span>
+            <span id="gamepadDisabled" class="hidden"><strong>Tip:</strong> Connect a gamepad controller (XBOX/PS3/PS4/etc) to use it to play.</span>
             <span id="gamepadRecognized" class="hidden">Gamepad is detected. You can play using it now. Just make sure the game is focused.</span>
             <span id="gamepadNotRecognized" class="hidden">Gamepad is detected but not recognized. Please submit an Issue on the Repository and we will help get it added</span>
         </p>

--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -234,6 +234,8 @@
 
         <p id="disableCssSection"><input id="disableCss" type="checkbox"/> <label for="disableCss"><strong>Check</strong> to see what a non-sighted user would experience (disables CSS)</label></p>
     
+        <p><button id="gameInstructionsButton">Help</button></p>
+
         <p id="gameSelectionSection">
             <button id="btnAdd" class="hidden">Add to Homescreen?</button>
             <label for="gameSelection">Currently playing:</label>
@@ -281,6 +283,13 @@
     
         <p id="authorSection" class="hidden"><small>By <a id="authorInfo" target="_window"></a></small></p>
 
+        <p id="gamepadSection">
+            <img id="gamepadIcon" alt="gamepad icon" width="42" height="42" src="./pwa-icon.svg"/>
+            <span id="gamepadDisabled" class="hidden"><strong>Tip:</strong> Connect a gamepad controller (XBOX/PS3/PS4/etc) to use it to play.</span>
+            <span id="gamepadRecognized" class="hidden">Gamepad is detected. You can play using it now. Just make sure the game is focused.</span>
+            <span id="gamepadNotRecognized" class="hidden">Gamepad is detected but not recognized. Please submit an Issue on the Repository and we will help get it added</span>
+        </p>
+    
     </div>
     
     <div id="fullscreenRoot">
@@ -306,12 +315,9 @@
     </button>
 
 
-    <div id="instructionsContainer">
+    <dialog id="gameInstructionsDialog">
         <div class="panel-header">
-            <h2 class="panel-title">Instructions</h2>
-            <button id="closeInstructions" aria-label="Close" class="close">
-                <span aria-hidden="true">×</span>
-            </button>
+            <h2 class="panel-title">How to Play</h2>
         </div>
         
         <div id="touchInstructionsSection">
@@ -333,14 +339,7 @@
                 <li><kbd>R</kbd> to Restart the current level</li>
             </ul>
         </div>
-    
-        <p id="gamepadSection">
-            <img id="gamepadIcon" alt="gamepad icon" width="42" height="42" src="./pwa-icon.svg"/>
-            <span id="gamepadDisabled" class="hidden"><strong>Tip:</strong> Connect a gamepad controller (XBOX/PS3/PS4/etc) to use it to play.</span>
-            <span id="gamepadRecognized" class="hidden">Gamepad is detected. You can play using it now. Just make sure the game is focused.</span>
-            <span id="gamepadNotRecognized" class="hidden">Gamepad is detected but not recognized. Please submit an Issue on the Repository and we will help get it added</span>
-        </p>
-    
+        
         <div id="gamepadSectionPWA">
             <p>
                 <img alt="gamepad icon" width="42" height="42" src="./pwa-icon.svg"/>
@@ -350,10 +349,9 @@
                 Partial Gamepad support. Up/Down/Left/Right works but not Action/Undo. See this <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=906347">Chrome Bug</a>
             </p>
         </div>
-        
-        <p id="sourceSection"><a href="https://github.com/philschatz/puzzlescript">Source On GitHub</a></p>
-        
-    </div>
+    
+        <button id="gameInstructionsDialogClose" title="Close">Close</button>
+    </dialog>
 
     <script type="text/javascript">//<![CDATA[
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -71,8 +71,9 @@ window.addEventListener('load', () => {
     const loadingIndicator = getElement('#loadingIndicator')
     const authorSection = getElement('#authorSection')
     const authorInfo = getElement('#authorInfo')
-    const instructionsContainer = getElement('#instructionsContainer')
-    const closeInstructions = getElement('#closeInstructions')
+    const gameInstructionsButton = getElement('#gameInstructionsButton')
+    const gameInstructionsDialog = getElement<Dialog>('#gameInstructionsDialog')
+    const gameInstructionsDialogClose = getElement('#gameInstructionsDialogClose')
     const fullscreenRoot = getElement('#fullscreenRoot')
     const enterFullscreen = getElement('#enterFullscreen')
     const exitFullscreen = getElement('#exitFullscreen')
@@ -80,6 +81,7 @@ window.addEventListener('load', () => {
     const messageDialogText = getElement('#messageDialogText')
     const messageDialogClose = getElement('#messageDialogClose')
     dialogPolyfill.registerDialog(messageDialog)
+    dialogPolyfill.registerDialog(gameInstructionsDialog)
 
     TimeAgo.addLocale(TimeAgoEn)
     const timeAgo = new TimeAgo('en-US')
@@ -183,10 +185,11 @@ window.addEventListener('load', () => {
         messageDialog.close()
     })
 
-    closeInstructions.addEventListener('click', () => {
-        instructionsContainer.classList.add('hidden')
-        // resize the game
-        tableEngine.resize()
+    gameInstructionsButton.addEventListener('click', () => {
+        gameInstructionsDialog.showModal()
+    })
+    gameInstructionsDialogClose.addEventListener('click', () => {
+        gameInstructionsDialog.close()
     })
 
     // Hide the fullscreen button if it is not available in the browser

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -72,12 +72,12 @@ window.addEventListener('load', () => {
     const authorSection = getElement('#authorSection')
     const authorInfo = getElement('#authorInfo')
     const gameInstructionsButton = getElement('#gameInstructionsButton')
+    const gameInstructionsButton2 = getElement('#gameInstructionsButton2')
     const gameInstructionsDialog = getElement<Dialog>('#gameInstructionsDialog')
     const gameInstructionsDialogClose = getElement('#gameInstructionsDialogClose')
     // const fullscreenRoot = getElement('#fullscreenRoot')
     // Like full screen but keep the browser bar. Also, alerts break fullscreen but not zenscreen
     const enterFullscreen = getElement('#enterFullscreen')
-    const enterFullscreen2 = getElement('#enterFullscreen2')
     const exitFullscreen = getElement('#exitFullscreen')
     const messageDialog = getElement<Dialog>('#messageDialog')
     const messageDialogText = getElement('#messageDialogText')
@@ -191,6 +191,9 @@ window.addEventListener('load', () => {
     gameInstructionsButton.addEventListener('click', () => {
         gameInstructionsDialog.showModal()
     })
+    gameInstructionsButton2.addEventListener('click', () => {
+        gameInstructionsDialog.showModal()
+    })
     gameInstructionsDialogClose.addEventListener('click', () => {
         gameInstructionsDialog.close()
         table.focus()
@@ -204,7 +207,8 @@ window.addEventListener('load', () => {
     //         enterFullscreen.style.display = 'none'
     //     }
     // }
-    const enterFullscreenHandler = () => {
+
+    enterFullscreen.addEventListener('click', () => {
         document.body.classList.add('is-zen-screen')
         // const el = fullscreenRoot as any
         // if (el.requestFullscreen) {
@@ -216,11 +220,9 @@ window.addEventListener('load', () => {
         // } else if (el.msRequestFullscreen) {
         //     el.msRequestFullscreen()
         // }
-        table.focus() // do not lose focus
         tableEngine.resize()
-    }
-    enterFullscreen.addEventListener('click', enterFullscreenHandler)
-    enterFullscreen2.addEventListener('click', enterFullscreenHandler)
+        table.focus() // do not lose focus
+    })
 
     exitFullscreen.addEventListener('click', () => {
         document.body.classList.remove('is-zen-screen')

--- a/src/pwa-app.ts
+++ b/src/pwa-app.ts
@@ -185,6 +185,7 @@ window.addEventListener('load', () => {
 
     messageDialogClose.addEventListener('click', () => {
         messageDialog.close()
+        table.focus()
     })
 
     gameInstructionsButton.addEventListener('click', () => {
@@ -192,6 +193,7 @@ window.addEventListener('load', () => {
     })
     gameInstructionsDialogClose.addEventListener('click', () => {
         gameInstructionsDialog.close()
+        table.focus()
     })
 
     // // Hide the fullscreen button if it is not available in the browser


### PR DESCRIPTION
When touch is detected, the touch instructions are available. Otherwise, show keyboard instructions.

Also, the buttons and various states have been simplified to make a simpler UI with a list of features visible on initial load.

## Default Page

![image](https://user-images.githubusercontent.com/253202/53866557-70782d80-3fb7-11e9-92fd-152b09e59d7b.png)

## Help Dialog

![image](https://user-images.githubusercontent.com/253202/53866611-900f5600-3fb7-11e9-85e9-377fc765cf25.png)

## Full Screen

![image](https://user-images.githubusercontent.com/253202/53866634-9dc4db80-3fb7-11e9-8d1b-509267a4f472.png)
