### PR TITLE
fix: resize is now bigger

### DIFF
--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -125,6 +125,7 @@
             padding: 1rem;
             border-radius: 6px;
             box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+            margin-right: 1rem; /* Keep some room between the bubble and the game */
         }
 
         @media screen and (orientation:portrait) {
@@ -160,8 +161,9 @@
             #theGame {
                 /* Ensure the game is always big */
                 flex-shrink: 0;
-                margin-left: 1rem;
-                margin-right: 1rem;
+                
+                /* Important because the ResizeHandler does not know how to compute with margins yet */
+                margin: 0;
             }
             #instructionsContainer {
                 flex-grow: 1;

--- a/src/browser/ResizeWatcher.ts
+++ b/src/browser/ResizeWatcher.ts
@@ -26,7 +26,7 @@ export default class ResizeWatcher {
         // Resize the table so that it fits.
         const levelRatio = this.columns / this.rows
         // Figure out if the width or the height is the limiting factor
-        const availableWidth = Math.min(window.outerWidth, window.innerWidth) - this.table.offsetLeft
+        const availableWidth = Math.min(window.outerWidth, window.innerWidth) - this.leftWithoutAutoMargins()
         const availableHeight = Math.min(window.outerHeight, window.innerHeight) - this.table.offsetTop
         let newWidth = 0
         if (availableWidth / levelRatio < availableHeight) {
@@ -41,5 +41,17 @@ export default class ResizeWatcher {
 
     public dispose() {
         window.removeEventListener('resize', this.boundResizeHandler)
+    }
+
+    private leftWithoutAutoMargins() {
+        const originalLeft = this.table.offsetLeft
+        const originalWidthStr = window.getComputedStyle(this.table).width
+        const originalWidth = originalWidthStr ? Number.parseFloat(originalWidthStr.replace(/px$/, '')) : 0
+
+        // check how much the offset moves by when we increase the width (to see if some parents are margin:auto;)
+        this.table.style.width = `${originalLeft * 2 + originalWidth}px`
+        const stretchedLeft = this.table.offsetLeft
+        this.table.style.width = originalWidthStr
+        return stretchedLeft
     }
 }


### PR DESCRIPTION
Previously, the size of the game was solely based on the `this.table.offsetLeft` which is a problem when a parent element has `margin: auto;` set. This caused the resized game to still be smaller than it could have been.

This change temporarily sets the width wider so all the `margin: auto` elements collapse their margins so `this.table.offsetLeft` shows how far left the game can go.