### PR TITLE
fix: display quirks in chrome and bottom-align games

### DIFF
--- a/pwa-template.xhtml
+++ b/pwa-template.xhtml
@@ -99,11 +99,14 @@
             }
         }
 
-        @media screen and (orientation:landscape) {
+        /* Chrome causes display quirks with fractional pixels
+         * so `margin: auto` is not sufficient
+         */
+        /* @media screen and (orientation:landscape) {
             #theGame {
                 margin: auto;
             }
-        }
+        } */
 
 
         .ui-button,
@@ -148,7 +151,12 @@
          * =================================================
          */
 
-        #fullscreenRoot { margin: auto; }
+        #fullscreenRoot { 
+            margin: auto;
+            position: fixed;
+            bottom: 0;
+            width: 100%; /* to horizontally center */
+        }
 
 
         #fullscreenButtons {

--- a/src/browser/ResizeWatcher.ts
+++ b/src/browser/ResizeWatcher.ts
@@ -2,12 +2,12 @@ import { _debounce } from '../util'
 
 export default class ResizeWatcher {
     private readonly table: HTMLTableElement
-    private readonly handler: (width: number) => void
+    private readonly handler: (width: number, left: number) => void
     private readonly boundResizeHandler: any
     private columns: number
     private rows: number
 
-    constructor(table: HTMLTableElement, handler: (width: number) => void) {
+    constructor(table: HTMLTableElement, handler: (width: number, left: number) => void) {
         this.table = table
         this.handler = handler
         this.columns = 1
@@ -26,7 +26,8 @@ export default class ResizeWatcher {
         // Resize the table so that it fits.
         const levelRatio = this.columns / this.rows
         // Figure out if the width or the height is the limiting factor
-        const availableWidth = Math.min(window.outerWidth, window.innerWidth) - this.leftWithoutAutoMargins()
+        const leftWithoutAutoMargins = this.leftWithoutAutoMargins()
+        const availableWidth = Math.min(window.outerWidth, window.innerWidth) - leftWithoutAutoMargins
         const availableHeight = Math.min(window.outerHeight, window.innerHeight) - this.table.offsetTop
         let newWidth = 0
         if (availableWidth / levelRatio < availableHeight) {
@@ -36,7 +37,8 @@ export default class ResizeWatcher {
             // Height is the limiting factor
             newWidth = Math.floor(availableHeight * levelRatio / this.rows / 5) * this.rows * 5
         }
-        this.handler(Math.floor(newWidth))
+        const leftOffset = availableWidth / 2 - newWidth / 2 - leftWithoutAutoMargins
+        this.handler(Math.floor(newWidth), Math.floor(leftOffset))
     }
 
     public dispose() {

--- a/src/browser/SyncTableEngine.ts
+++ b/src/browser/SyncTableEngine.ts
@@ -135,9 +135,11 @@ export default class SyncTableEngine implements Engineish {
         this.subEngine.start()
         this.handler.onResume()
     }
-    private handleResize(width: number) {
+    private handleResize(width: number, left: number) {
         if (!this.subEngine.getEngine().isCurrentLevelAMessage()) {
-            this.table.setAttribute('style', `width: ${width}px;`)
+            this.table.setAttribute('style', `width: ${width}px`)
+            // to fix chrome vertical lines because of fractional pixels
+            this.table.parentElement && this.table.parentElement.setAttribute('style', `left: ${left}px; /*chrome display quirk with fractional pixels*/`)
         }
     }
 }

--- a/src/browser/WebworkerTableEngine.ts
+++ b/src/browser/WebworkerTableEngine.ts
@@ -240,9 +240,11 @@ export default class WebworkerTableEngine implements Engineish {
     private isCurrentLevelAMessage() {
         return this.getGameData().levels[this.levelNum].type === LEVEL_TYPE.MESSAGE
     }
-    private handleResize(width: number) {
+    private handleResize(width: number, left: number) {
         if (!this.isCurrentLevelAMessage()) {
-            this.table.setAttribute('style', `width: ${width}px;`)
+            this.table.setAttribute('style', `width: ${width}px`)
+            // to fix chrome vertical lines because of fractional pixels
+            this.table.parentElement && this.table.parentElement.setAttribute('style', `left: ${left}px; /*chrome display quirk with fractional pixels*/`)
         }
     }
 }

--- a/src/pwa/browseGames.ts
+++ b/src/pwa/browseGames.ts
@@ -13,7 +13,12 @@ const POPULAR_GAMES = [
     'swapbot',
     'bubble-butler',
     'flying-kick',
-    'pushcat-jr'
+    'beam-islands',
+    'pushcat-jr',
+    'icecrates',
+    'sokobond',
+    'spooky-pumpkin-game',
+    'spikes-n-stuff'
 ]
 
 const DEFINITELY_OTHER = [


### PR DESCRIPTION
This is caused because of fractional pixels when `margin: auto;` is used in Chrome
![image](https://user-images.githubusercontent.com/253202/54249274-8339b780-450d-11e9-812f-edd5261e9b9a.png)
