### PR TITLE
feat: report when playing standalone

### DIFF
--- a/src/pwa/app.ts
+++ b/src/pwa/app.ts
@@ -36,6 +36,13 @@ window.addEventListener('load', () => {
                 body.setAttribute('data-mode', 'playingGame')
                 const showTable = !!showTableStr && showTableStr.toLowerCase() === 'true'
                 playGame(gameId, levelStr ? Number.parseInt(levelStr, 10) : null, showTable)
+
+                // Send event when user is playing in standalone mode
+                const isInStandaloneMode = window.matchMedia('(display-mode: standalone)').matches || 'standalone' in window.navigator
+                if (isInStandaloneMode) {
+                    sendAnalytics('send', 'event', 'pwa', 'play')
+                }
+
             } else if (!hash) {
                 // Browse the games
                 htmlTitle.textContent = originalTitle

--- a/src/pwa/util.ts
+++ b/src/pwa/util.ts
@@ -3,7 +3,9 @@ import { Optional } from '../util'
 declare const ga: Optional<(a1: string, a2: string, a3?: string, a4?: string, a5?: string, a6?: number) => void>
 
 export function sendAnalytics(a1: string, a2: string, a3?: string, a4?: string, a5?: string, a6?: number) {
-    ga && ga(a1, a2, a3, a4, a5, a6)
+    if (!window.localStorage.getItem('disableAnalytics')) {
+        ga && ga(a1, a2, a3, a4, a5, a6)
+    }
 }
 
 export function getElement<T extends HTMLElement>(selector: string) {

--- a/src/pwa/util.ts
+++ b/src/pwa/util.ts
@@ -16,10 +16,8 @@ export function getElement<T extends HTMLElement>(selector: string) {
 
 export const changePage = (gameId: string, level: number) => {
     history.replaceState(undefined, undefined as any as string, `#/${gameId}/${level}`)
-    if (ga) {
-        const { pathname, search } = window.location
-        ga('set', 'page', `${pathname}${search}#/${gameId}/${level}`)
-        // ga('set', 'title', gameTitle)
-        ga('send', 'pageview')
-    }
+    const { pathname, search } = window.location
+    sendAnalytics('set', 'page', `${pathname}${search}#/${gameId}/${level}`)
+    // ga('set', 'title', gameTitle)
+    sendAnalytics('send', 'pageview')
 }


### PR DESCRIPTION
It is useful to see how often people install the Progressive Web App since it takes a few more hurdles to do but it ends up on the home screen