### PR TITLE
chore: Improve Performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "inquirer-autocomplete-prompt": "^1.0.1",
     "nearley": "github:philschatz/nearley#24685991e203fd6645a6f687198687aa42b7d6f2",
     "pify": "^4.0.0",
-    "quick-lru": "^2.0.0",
     "supports-color": "^6.0.0",
     "update-notifier": "^2.5.0",
     "web-audio-api": "^0.2.2"

--- a/src/lruCache.ts
+++ b/src/lruCache.ts
@@ -1,12 +1,42 @@
-import QuickLru from 'quick-lru'
-
-export default class LruCache<Key, Value> {
-    private lru: QuickLru<Key, Value>
+class QuickLru<V> {
+    private size: number
+    private cache: { [key: string]: V}
+    private oldCache: { [key: string]: V}
+    private readonly maxSize: number
     constructor(maxSize: number) {
-        this.lru = new QuickLru({ maxSize })
+        this.maxSize = maxSize
+        this.size = 0
+        this.cache = {}
+        this.oldCache = {}
     }
 
-    public get(key: Key, valueFn: () => Value) {
+    public set(key: string, value: V) {
+        const has = typeof this.cache[key] !== 'undefined' || typeof this.oldCache[key] !== 'undefined'
+        if (this.size > this.maxSize) {
+            this.oldCache = this.cache
+            this.size = 0
+        }
+        if (!has) {
+            this.cache[key] = value
+            this.size++
+        }
+    }
+    public get(key: string): V | undefined {
+        const value = this.cache[key]
+        if (typeof value !== 'undefined') {
+            return value
+        }
+        return this.oldCache[key]
+    }
+}
+
+export default class LruCache<Value> {
+    private lru: QuickLru<Value>
+    constructor(maxSize: number) {
+        this.lru = new QuickLru(maxSize)
+    }
+
+    public get(key: string, valueFn: () => Value) {
         const val = this.lru.get(key)
         // speed up by combining .has(key) and .get(key)
         if (val !== undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6413,11 +6413,6 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-quick-lru@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-2.0.0.tgz#32b017b28d1784631c8ab0a1ed2978e094dbe181"
-  integrity sha512-DqOtZziv7lDjEyuqyVQacRciAwMCEjTNrLYCHYEIIgjcE/tLEpBF82hiDIwCjRnEL9/hY2GJxA0T8ZvYvVVSSA==
-
 railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"


### PR DESCRIPTION
These speed up the communication between the webworker and the main UI thread by reducing the size of messages being passed around and the number of pixels that need to be updated:

- reduce the set of changedCells to only be the ones that actually changed
- reduce the set of accessibility messages to only ones where the cells changed

It also replaces the `quick-lru` Map with a vanilla object map since the keys are always strings and `object[key]` lookup is faster than `Map.get(...)`